### PR TITLE
fix: limit 5x cpu, 120% memory, add cpuLimit and memoryLimit

### DIFF
--- a/charts/common/templates/deployment.yaml
+++ b/charts/common/templates/deployment.yaml
@@ -55,8 +55,16 @@ spec:
               protocol: TCP
           resources:
             limits:
-              cpu: {{ .Values.container.cpu }}
-              memory: "{{ .Values.container.memory }}Mi"
+              {{- if .Values.container.cpuLimit }}
+              cpu: {{ .Values.container.cpuLimit }}
+              {{- else }}
+              cpu: "{{ .Values.container.cpuLimit | default .Values.container.cpu | toString | replace "." "" | int64 | mul 500 }}m" #TODO: fix when mulf is working
+              {{- end }}
+              {{- if .Values.container.memoryLimit }}
+              memory: "{{ .Values.container.memoryLimit }}Mi"
+              {{- else }}
+              memory: "{{ (div (mul .Values.container.memory 6) 5) }}Mi" #TODO: same as above, fix when mulf is working
+              {{- end }}
             requests:
               cpu: {{ .Values.container.cpu }}
               memory: "{{ .Values.container.memory }}Mi"

--- a/charts/common/tests/deployment_test.yaml
+++ b/charts/common/tests/deployment_test.yaml
@@ -45,6 +45,78 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].envFrom[0].configMapRef.name
           value: testsuite
+  - it: cpu limit can be overridden
+    release:
+    set:
+      <<: *values
+      container:
+        image: img
+        cpu: 0.1
+        cpuLimit: 1
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.cpu
+          value: 1
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.cpu
+          value: 0.1
+  - it: cpu limit is 5x request for < 0
+    release:
+    set:
+      <<: *values
+      container:
+        image: img
+        cpu: 0.1
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.cpu
+          value: 500m
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.cpu
+          value: 0.1
+  - it: cpu limit is 5x request for > 1
+    release:
+    set:
+      <<: *values
+      container:
+        image: img
+        cpu: 2.1
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.cpu
+          value: 10500m
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.cpu
+          value: 2.1
+  - it: memory limit is 120 percent of request
+    release:
+    set:
+      <<: *values
+      container:
+        image: img
+        memory: 256
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.memory
+          value: 307Mi
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.memory
+          value: 256Mi
+  - it: memory limit can be overridden
+    release:
+    set:
+      <<: *values
+      container:
+        image: img
+        memory: 256
+        memoryLimit: 1024
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.memory
+          value: 1024Mi
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.memory
+          value: 256Mi
   - it: must enable prometheus if enabled
     set:
       <<: *values


### PR DESCRIPTION
Default behaviour will now set `limits.cpu = requests.cpu * 5` and `limits.memory = 1.2 * requests.memory`.
You can override this convention with `container.cpuLimit` and `container.memoryLimit`

Closes #1 