### PR TITLE
fix: enable forceReplicas to run with 1 replica in prod

### DIFF
--- a/charts/common/templates/deployment.yaml
+++ b/charts/common/templates/deployment.yaml
@@ -4,6 +4,7 @@
 {{- $shortname := .Values.shortname | required ".Values.common.shortname is required." -}}
 {{- $team := .Values.team | required ".Values.common.team is required." -}}
 {{- $image := .Values.container.image | required ".Values.common.container.image is required." -}}
+{{- $replicas := .Values.container.forceReplicas | default .Values.replicas -}}
 
 {{- /* YAML Spec */}}
 apiVersion: apps/v1
@@ -17,7 +18,7 @@ spec:
   selector:
     matchLabels:
       app: {{ .Release.Name }}
-  replicas: {{ .Values.container.replicas }}
+  replicas: {{ $replicas }}
   template:
     metadata:
       annotations:

--- a/charts/common/templates/hpa.yaml
+++ b/charts/common/templates/hpa.yaml
@@ -1,9 +1,7 @@
 {{- /* Rules */}}
 {{- $env := .Values.env | required ".Values.common.env is required." -}}
 
-{{- if .Values.container.forceReplicas }}
-  {{- /* Nothing to do, skip this*/}}
-{{- else if (or (eq "prd" .Values.env) .Values.container.maxReplicas) }}
+{{- if (and (not .Values.container.forceReplicas) (or (eq "prd" .Values.env) .Values.container.maxReplicas)) }}
   {{- /* Defaults */}}
   {{- $maxReplicas := .Values.container.maxReplicas | default 10 }}
   {{- $cpuUtilization := 80 }}

--- a/charts/common/templates/hpa.yaml
+++ b/charts/common/templates/hpa.yaml
@@ -1,7 +1,9 @@
 {{- /* Rules */}}
 {{- $env := .Values.env | required ".Values.common.env is required." -}}
 
-{{- if (or (eq "prd" .Values.env) .Values.container.maxReplicas) }}
+{{- if .Values.container.forceReplicas }}
+  {{- /* Nothing to do, skip this*/}}
+{{- else if (or (eq "prd" .Values.env) .Values.container.maxReplicas) }}
   {{- /* Defaults */}}
   {{- $maxReplicas := .Values.container.maxReplicas | default 10 }}
   {{- $cpuUtilization := 80 }}

--- a/charts/common/templates/pdb.yaml
+++ b/charts/common/templates/pdb.yaml
@@ -1,7 +1,9 @@
 {{- /* Rules */}}
 {{- $env := .Values.env | required ".Values.common.env is required." -}}
 
-{{- if (or (eq "prd" .Values.env) .Values.container.minAvailable) }}
+{{- if .Values.container.forceReplicas }}
+  {{- /* Nothing to do, skip this*/}}
+{{- else if (or (eq "prd" .Values.env) .Values.container.minAvailable) }}
   {{- if (and (ne "prd" .Values.env) (eq 1 (int .Values.container.replicas))) }}
     {{ $checkReplicas := .Values.error | required ".Values.common.container.replicas must be greater than 1 when using minAvailable" }}
   {{- end }}

--- a/charts/common/templates/pdb.yaml
+++ b/charts/common/templates/pdb.yaml
@@ -1,9 +1,7 @@
 {{- /* Rules */}}
 {{- $env := .Values.env | required ".Values.common.env is required." -}}
 
-{{- if .Values.container.forceReplicas }}
-  {{- /* Nothing to do, skip this*/}}
-{{- else if (or (eq "prd" .Values.env) .Values.container.minAvailable) }}
+{{- if (and (not .Values.container.forceReplicas) (or (eq "prd" .Values.env) .Values.container.minAvailable) )}}
   {{- if (and (ne "prd" .Values.env) (eq 1 (int .Values.container.replicas))) }}
     {{ $checkReplicas := .Values.error | required ".Values.common.container.replicas must be greater than 1 when using minAvailable" }}
   {{- end }}

--- a/charts/common/tests/deployment_test.yaml
+++ b/charts/common/tests/deployment_test.yaml
@@ -155,3 +155,34 @@ tests:
       - equal:
           path: spec.template.spec.containers[1].envFrom[0].configMapRef.name
           value: testsuite-psql-connection
+  - it: must use 3 replicas if replicas is 3
+    set:
+      <<: *values
+      env: dev
+      replicas: 3
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 3
+  - it: must use 1 replica if forceReplica is 1
+    set:
+      <<: *values
+      env: prd
+      container:
+        image: some
+        forceReplicas: 1
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 1
+  - it: must use 3 replica if forceReplica is 3
+    set:
+      <<: *values
+      env: prd
+      container:
+        image: some
+        forceReplicas: 3
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 3

--- a/charts/common/tests/deployment_test.yaml
+++ b/charts/common/tests/deployment_test.yaml
@@ -164,7 +164,7 @@ tests:
       - equal:
           path: spec.replicas
           value: 3
-  - it: must use 1 replica if forceReplica is 1
+  - it: must use 1 replica if forceReplicas is 1
     set:
       <<: *values
       env: prd
@@ -175,7 +175,7 @@ tests:
       - equal:
           path: spec.replicas
           value: 1
-  - it: must use 3 replica if forceReplica is 3
+  - it: must use 3 replica if forceReplicas is 3
     set:
       <<: *values
       env: prd

--- a/charts/common/tests/hpa_test.yaml
+++ b/charts/common/tests/hpa_test.yaml
@@ -55,7 +55,7 @@ tests:
       - equal:
           path: spec.maxReplicas
           value: 10
-  - it: must not use hpa if forceReplica is set
+  - it: must not use hpa if forceReplicas is set
     set:
       <<: *values
       env: prd

--- a/charts/common/tests/hpa_test.yaml
+++ b/charts/common/tests/hpa_test.yaml
@@ -55,3 +55,13 @@ tests:
       - equal:
           path: spec.maxReplicas
           value: 10
+  - it: must not use hpa if forceReplica is set
+    set:
+      <<: *values
+      env: prd
+      container:
+        image: some
+        forceReplicas: 1
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/common/tests/pdb_test.yaml
+++ b/charts/common/tests/pdb_test.yaml
@@ -32,3 +32,13 @@ tests:
       - equal:
           path: spec.minAvailable
           value: "50%"
+  - it: must not use pdb if forceReplica is set
+    set:
+      <<: *values
+      env: prd
+      container:
+        image: some
+        forceReplicas: 1
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/common/tests/pdb_test.yaml
+++ b/charts/common/tests/pdb_test.yaml
@@ -32,7 +32,7 @@ tests:
       - equal:
           path: spec.minAvailable
           value: "50%"
-  - it: must not use pdb if forceReplica is set
+  - it: must not use pdb if forceReplicas is set
     set:
       <<: *values
       env: prd


### PR DESCRIPTION
Will enable `forceReplicas: 1` to run with 1 replica in production. The deployment will not have a PDB nor a HPA.