### PR TITLE
fix: enable custom values through common.values closes #11

### DIFF
--- a/charts/common/templates/_helpers.tpl
+++ b/charts/common/templates/_helpers.tpl
@@ -4,6 +4,9 @@ shortname: {{ .Values.shortname }}
 team: {{ .Values.team }}
 common: {{ .Chart.Version }}
 environment: {{ .Values.env }}
+{{- if .Values.labels }}
+{{ toYaml .Values.labels }}
+{{- end }}
 {{- end }}
 
 {{- define "gcloud_sql_proxy" }}

--- a/charts/common/templates/deployment.yaml
+++ b/charts/common/templates/deployment.yaml
@@ -30,6 +30,9 @@ spec:
         {{- end }}
       labels:
         {{- include "labels" . | indent 8 }}
+        {{- if .Values.container.labels }}
+        {{- toYaml .Values.container.labels | nindent 8 }}
+        {{- end }}
     spec:
       serviceAccountName: application
 

--- a/charts/common/tests/deployment_test.yaml
+++ b/charts/common/tests/deployment_test.yaml
@@ -17,7 +17,11 @@ tests:
     set:
       <<: *values
       labels:
-        version: 1
+        custom: label
+      container:
+        image: img
+        labels:
+          version: 1
     asserts:
       - isNotEmpty:
           template: deployment.yaml
@@ -27,7 +31,10 @@ tests:
           path: metadata.labels.environment
       - isNotEmpty:
           template: deployment.yaml
-          path: metadata.labels.version
+          path: metadata.labels.custom
+      - isNotEmpty:
+          template: deployment.yaml
+          path: spec.template.metadata.labels.version
   - it: must add to env if listed
     set:
       <<: *values

--- a/charts/common/tests/deployment_test.yaml
+++ b/charts/common/tests/deployment_test.yaml
@@ -16,6 +16,8 @@ tests:
   - it: must have labels
     set:
       <<: *values
+      labels:
+        version: 1
     asserts:
       - isNotEmpty:
           template: deployment.yaml
@@ -23,6 +25,9 @@ tests:
       - isNotEmpty:
           template: deployment.yaml
           path: metadata.labels.environment
+      - isNotEmpty:
+          template: deployment.yaml
+          path: metadata.labels.version
   - it: must add to env if listed
     set:
       <<: *values

--- a/charts/common/values-ci-tests.yaml
+++ b/charts/common/values-ci-tests.yaml
@@ -20,7 +20,7 @@ service:
 container:
   image: nginxinc/nginx-unprivileged:latest
   labels:
-    version: 11
+    version: v1.2.3
   cpu: 1
   memory: 128
   replicas: 1

--- a/charts/common/values-ci-tests.yaml
+++ b/charts/common/values-ci-tests.yaml
@@ -2,6 +2,9 @@ app: mytest
 shortname: mytst
 team: team
 
+labels:
+  custom: label
+
 env: dev
 
 ingress:

--- a/charts/common/values-ci-tests.yaml
+++ b/charts/common/values-ci-tests.yaml
@@ -2,10 +2,12 @@ app: mytest
 shortname: mytst
 team: team
 
+env: dev
+
+# common labels for all resources
 labels:
   custom: label
 
-env: dev
 
 ingress:
   host: mytest.dev.entur.io
@@ -17,6 +19,8 @@ service:
 
 container:
   image: nginxinc/nginx-unprivileged:latest
+  labels:
+    version: 11
   cpu: 1
   memory: 128
   replicas: 1

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -3,6 +3,8 @@
 # team: yourteam
 # env: dev
 
+labels: []
+
 ingress:
   enabled: true
   # host: app.dev.entur.io
@@ -13,6 +15,7 @@ service:
   internalPort: 8080
 
 container:
+  labels: []
   cpu: 0.1
   memory: 16
   uid: 1000

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -3,7 +3,7 @@
 # team: yourteam
 # env: dev
 
-labels: []
+labels: {}
 
 ingress:
   enabled: true
@@ -15,7 +15,7 @@ service:
   internalPort: 8080
 
 container:
-  labels: []
+  labels: {}
   cpu: 0.1
   memory: 16
   uid: 1000


### PR DESCRIPTION
This is a fix #11 PR

Will enable teams to have f.ex:
```yaml
common:
  labels:
    domain: sales
  container:
    labels:
      version: v1.2.3
```