### PR TITLE
feat: Allow setting cloudsqlproxy resource limits via values

### DIFF
--- a/charts/common/templates/_helpers.tpl
+++ b/charts/common/templates/_helpers.tpl
@@ -29,8 +29,16 @@ environment: {{ .Values.env }}
       type: RuntimeDefault
   resources:
     limits:
+      {{- if .Values.postgres.cpuLimit }}
+      cpu: {{ .Values.postgres.cpuLimit }}
+      {{- else }}
       cpu: {{ .Values.postgres.cpu }}
+      {{- end }}
+      {{- if .Values.postgres.memoryLimit }}
+      memory: "{{ .Values.postgres.memoryLimit }}Mi"
+      {{- else }}
       memory: "{{ .Values.postgres.memory }}Mi"
+      {{- end }}
     requests:
       cpu: {{ .Values.postgres.cpu }}
       memory: "{{ .Values.postgres.memory }}Mi"

--- a/charts/common/templates/_helpers.tpl
+++ b/charts/common/templates/_helpers.tpl
@@ -34,11 +34,7 @@ environment: {{ .Values.env }}
       {{- else }}
       cpu: {{ .Values.postgres.cpu }}
       {{- end }}
-      {{- if .Values.postgres.memoryLimit }}
-      memory: "{{ .Values.postgres.memoryLimit }}Mi"
-      {{- else }}
       memory: "{{ .Values.postgres.memory }}Mi"
-      {{- end }}
     requests:
       cpu: {{ .Values.postgres.cpu }}
       memory: "{{ .Values.postgres.memory }}Mi"

--- a/charts/common/tests/deployment_test.yaml
+++ b/charts/common/tests/deployment_test.yaml
@@ -195,6 +195,21 @@ tests:
       - equal:
           path: spec.template.spec.containers[1].envFrom[0].configMapRef.name
           value: testsuite-psql-connection
+  - it: postgres cpu limit can be overridden
+    release:
+    set:
+      <<: *values
+      postgres:
+        enabled: true
+        cpu: 0.1
+        cpuLimit: 1
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[1].resources.limits.cpu
+          value: 1
+      - equal:
+          path: spec.template.spec.containers[1].resources.requests.cpu
+          value: 0.1
   - it: must use 3 replicas if replicas is 3
     set:
       <<: *values


### PR DESCRIPTION
This should enable "fixing" throttling for cloudsqlproxy containers without affecting Harness efficiency score

I think this is a correct view for current throttling (ent-kub-prd):

https://grafana-ha.entur.org/explore?left=%7B%22datasource%22:%22prometheus-thanos%22,%22queries%22:%5B%7B%22datasource%22:%7B%22type%22:%22prometheus%22,%22uid%22:%22000000002%22%7D,%22editorMode%22:%22code%22,%22expr%22:%22sum%20by%20(container,%20pod,%20namespace)%20(%5Cn%20%20%20%20rate%20(container_cpu_cfs_throttled_periods_total%7Bcontainer%3D~%5C%22.*proxy.*%5C%22,prometheus_group%3D~%5C%22%5Ekub-ent-prd-001$%5C%22%7D%5B2m%5D)%5Cn%20%20%20%20%20%2F%5Cn%20%20%20%20rate%20(container_cpu_cfs_periods_total%5B2m%5D)%5Cn)%20%3E%200.1%22,%22interval%22:%22%22,%22range%22:true,%22refId%22:%22A%22%7D%5D,%22range%22:%7B%22from%22:%22now-3h%22,%22to%22:%22now%22%7D%7D&orgId=1