### PR TITLE
fix: add pdb for forceReplicas > 1

### DIFF
--- a/charts/common/templates/pdb.yaml
+++ b/charts/common/templates/pdb.yaml
@@ -1,7 +1,7 @@
 {{- /* Rules */}}
 {{- $env := .Values.env | required ".Values.common.env is required." -}}
 
-{{- if (and (not .Values.container.forceReplicas) (or (eq "prd" .Values.env) .Values.container.minAvailable) )}}
+{{- if (and (not (eq (int .Values.container.forceReplicas) 1)) (or (eq "prd" .Values.env) .Values.container.minAvailable) )}}
   {{- if (and (ne "prd" .Values.env) (eq 1 (int .Values.container.replicas))) }}
     {{ $checkReplicas := .Values.error | required ".Values.common.container.replicas must be greater than 1 when using minAvailable" }}
   {{- end }}

--- a/charts/common/tests/pdb_test.yaml
+++ b/charts/common/tests/pdb_test.yaml
@@ -32,7 +32,7 @@ tests:
       - equal:
           path: spec.minAvailable
           value: "50%"
-  - it: must not use pdb if forceReplicas is set
+  - it: must not use pdb if forceReplicas is set to 1
     set:
       <<: *values
       env: prd
@@ -42,3 +42,13 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
+  - it: must use pdb if forceReplicas is set to more than 1
+    set:
+      <<: *values
+      env: prd
+      container:
+        image: some
+        forceReplicas: 2
+    asserts:
+      - hasDocuments:
+          count: 1


### PR DESCRIPTION
When more than one replica is forced, we still want a PDB.