### PR TITLE
feat: multiple ports, multiple deployments, override pdb and hpa

### DIFF
--- a/charts/common/README.md
+++ b/charts/common/README.md
@@ -1,6 +1,6 @@
 # common
 
-![Version: 1.2.8](https://img.shields.io/badge/Version-1.2.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square)
+![Version: 1.2.9](https://img.shields.io/badge/Version-1.2.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square)
 
 A Helm chart for Entur's Kubernetes workloads
 
@@ -29,6 +29,7 @@ Highlighted features:
 | container.memory | int | 16 | Set memory without any unit, `Mi` is inferred |
 | container.memoryLimit | string | `1.2 * memory` | Set memory limit without any unit, `Mi` is inferred |
 | container.minAvailable | string | 50% | Set the minimal available replicas, used by PDB |
+| container.name | string | .app | Name of container |
 | container.probes.liveness.failureThreshold | int | 6 | Set the failure threshold |
 | container.probes.liveness.path | string | /actuator/health/liveness | Set the path for liveness probe |
 | container.probes.liveness.periodSeconds | int | 5 | Set the period of checking |
@@ -39,13 +40,31 @@ Highlighted features:
 | container.probes.startup.periodSeconds | int | 1 | Set the period of checking |
 | container.prometheus.enabled | bool | `false` | Enable or disable Prometheus |
 | container.prometheus.path | string | /actuator/prometheus | Set the path for scraping metrics |
+| container.prometheus.port | int | service.internalPort | Set the port for prometheus scraping |
 | container.replicas | int | 1 | Set the target replica count |
 | container.terminationGracePeriodSeconds | int | `nil` | Override pod terminationGracePeriodSeconds (default 30s). |
 | container.uid | int | 1000 | Set the uid that your user runs with |
-| container.volumeMounts | object | `{}` | Configure volume mounts, accepts kubernetes syntax |
-| container.volumes | object | `{}` | Configure volume, accepts kubernetes syntax |
+| container.volumeMounts | list | `[]` | Configure volume mounts, accepts kubernetes syntax |
+| container.volumes | list | `[]` | Configure volume, accepts kubernetes syntax |
+| containers | list | `[]` | Takes a list of `container` entries, you must add a `name` field for each entry |
+| cron.concurrencyPolicy | string | Forbid | Concurrency policy, default `Forbid` |
+| cron.enabled | bool | `true` | Enable or disable the cron job |
+| cron.failedJobsHistoryLimit | int | 1 | Failed jobs history limit, default 1 |
+| cron.labels | object | `{}` | Add labels to your pods |
+| cron.schedule | string | `nil` | Required crontab schedule `* * * * * *` |
+| cron.successfulJobsHistoryLimit | int | 1 | Successful jobs history limit, default 1 |
+| cron.suspend | string | false | Suspend flag, default `false` |
+| cron.terminationGracePeriodSeconds | int | false | Override pod terminationGracePeriodSeconds (default 30s). |
+| cron.volumes | list | `[]` | Configure volume, accepts kubernetes syntax |
+| deployment.enabled | bool | `true` | Enable or disable the deployment |
+| deployment.forceReplicas | int | `nil` | Force replicas disables autoscaling, if set to 1 it will use Recreate strategy |
+| deployment.labels | object | `{}` | Add labels to your pods |
+| deployment.replicas | string | container.replicas | Set the target replica count |
+| deployment.terminationGracePeriodSeconds | int | `nil` | Override pod terminationGracePeriodSeconds (default 30s). |
+| deployment.volumes | list | `[]` | Configure volume, accepts kubernetes syntax |
 | env | string | `nil` | The current env, override in your `values-kub-ent-$env.yaml` files to `dev`, `tst` or `prd` |
 | grpc | bool | `false` | Enable gRPC which will add an annotation and use grpc probes |
+| hpa | string | `nil` |  |
 | ingress.enabled | bool | `true` | Enable or disable the ingress |
 | ingress.host | string | `nil` | Set the host name, do this in your `values-kub-ent-$env.yaml` files |
 | ingress.trafficType | string | `nil` | Set the traffic type, typically `api` or `public` |

--- a/charts/common/README.md
+++ b/charts/common/README.md
@@ -48,7 +48,7 @@ Highlighted features:
 | container.volumes | list | `[]` | Configure volume, accepts kubernetes syntax |
 | containers | list | `[]` | Takes a list of `container` entries, you must add a `name` field for each entry |
 | cron.concurrencyPolicy | string | Forbid | Concurrency policy |
-| cron.enabled | bool | `true` | Enable or disable the cron job |
+| cron.enabled | bool | `false` | Enable or disable the cron job |
 | cron.failedJobsHistoryLimit | int | 1 | Failed jobs history limit |
 | cron.labels | object | `{}` | Add labels to your pods |
 | cron.schedule | string | `nil` | Required crontab schedule `* * * * * *` |

--- a/charts/common/README.md
+++ b/charts/common/README.md
@@ -62,13 +62,14 @@ Highlighted features:
 | deployment.replicas | string | container.replicas | Set the target replica count |
 | deployment.terminationGracePeriodSeconds | int | `nil` | Override pod terminationGracePeriodSeconds (default 30s). |
 | deployment.volumes | list | `[]` | Configure volume, accepts kubernetes syntax |
+| deployments | list | `[]` | Specify a list of `deployment` specs |
 | env | string | `nil` | The current env, override in your `values-kub-ent-$env.yaml` files to `dev`, `tst` or `prd` |
 | grpc | bool | `false` | Enable gRPC which will add an annotation and use grpc probes |
 | hpa.spec | string | `nil` | Custom spec for HPA, inherits `scaleTargetRef` and min/max replicas. |
 | ingress.enabled | bool | `true` | Enable or disable the ingress |
 | ingress.host | string | `nil` | Set the host name, do this in your `values-kub-ent-$env.yaml` files |
 | ingress.trafficType | string | `nil` | Set the traffic type, typically `api` or `public` |
-| ingresses | list | `[]` | Specify a list of `ingress` stanzas |
+| ingresses | list | `[]` | Specify a list of `ingress` specs |
 | labels | object | `{ app shortname team common:version environment }` | Specify additional labels for every resource |
 | pdb.minAvailable | string | 50% | Set minimum available % |
 | postgres.cpu | float | 0.05 | Configure cpu request for proxy |

--- a/charts/common/README.md
+++ b/charts/common/README.md
@@ -64,10 +64,11 @@ Highlighted features:
 | deployment.volumes | list | `[]` | Configure volume, accepts kubernetes syntax |
 | env | string | `nil` | The current env, override in your `values-kub-ent-$env.yaml` files to `dev`, `tst` or `prd` |
 | grpc | bool | `false` | Enable gRPC which will add an annotation and use grpc probes |
-| hpa | string | `nil` |  |
+| hpa.spec | string | `nil` | Custom spec for HPA, inherits `scaleTargetRef` and min/max replicas. |
 | ingress.enabled | bool | `true` | Enable or disable the ingress |
 | ingress.host | string | `nil` | Set the host name, do this in your `values-kub-ent-$env.yaml` files |
 | ingress.trafficType | string | `nil` | Set the traffic type, typically `api` or `public` |
+| ingresses | list | `[]` | Specify a list of `ingress` stanzas |
 | labels | object | `{ app shortname team common:version environment }` | Specify additional labels for every resource |
 | pdb.minAvailable | string | 50% | Set minimum available % |
 | postgres.cpu | float | 0.05 | Configure cpu request for proxy |

--- a/charts/common/README.md
+++ b/charts/common/README.md
@@ -47,13 +47,13 @@ Highlighted features:
 | container.volumeMounts | list | `[]` | Configure volume mounts, accepts kubernetes syntax |
 | container.volumes | list | `[]` | Configure volume, accepts kubernetes syntax |
 | containers | list | `[]` | Takes a list of `container` entries, you must add a `name` field for each entry |
-| cron.concurrencyPolicy | string | Forbid | Concurrency policy, default `Forbid` |
+| cron.concurrencyPolicy | string | Forbid | Concurrency policy |
 | cron.enabled | bool | `true` | Enable or disable the cron job |
-| cron.failedJobsHistoryLimit | int | 1 | Failed jobs history limit, default 1 |
+| cron.failedJobsHistoryLimit | int | 1 | Failed jobs history limit |
 | cron.labels | object | `{}` | Add labels to your pods |
 | cron.schedule | string | `nil` | Required crontab schedule `* * * * * *` |
-| cron.successfulJobsHistoryLimit | int | 1 | Successful jobs history limit, default 1 |
-| cron.suspend | string | false | Suspend flag, default `false` |
+| cron.successfulJobsHistoryLimit | int | 1 | Successful jobs history limit |
+| cron.suspend | string | false | Suspend flag |
 | cron.terminationGracePeriodSeconds | int | false | Override pod terminationGracePeriodSeconds (default 30s). |
 | cron.volumes | list | `[]` | Configure volume, accepts kubernetes syntax |
 | deployment.enabled | bool | `true` | Enable or disable the deployment |
@@ -69,6 +69,7 @@ Highlighted features:
 | ingress.host | string | `nil` | Set the host name, do this in your `values-kub-ent-$env.yaml` files |
 | ingress.trafficType | string | `nil` | Set the traffic type, typically `api` or `public` |
 | labels | object | `{ app shortname team common:version environment }` | Specify additional labels for every resource |
+| pdb.minAvailable | string | 50% | Set minimum available % |
 | postgres.cpu | float | 0.05 | Configure cpu request for proxy |
 | postgres.cpuLimit | float | `nil` | Configure cpu limit for proxy |
 | postgres.enabled | bool | false | Enable or disable the proxy |

--- a/charts/common/templates/_helpers.tpl
+++ b/charts/common/templates/_helpers.tpl
@@ -9,35 +9,14 @@ environment: {{ .Values.env }}
 {{- end }}
 {{- end }}
 
-{{- define "gcloud_sql_proxy" }}
-- name: "{{ .Values.app }}-sql-proxy"
-  image: gcr.io/cloudsql-docker/gce-proxy:1.30.1
-  command:
-    - "/cloud_sql_proxy"
-    - "-verbose=false"
-    - "-log_debug_stdout"
-    - "-term_timeout=30s"
-  envFrom:
-  - configMapRef:
-      name: {{ .Values.app }}-psql-connection
-  securityContext:
-    runAsNonRoot: true
-    allowPrivilegeEscalation: false
-    capabilities:
-      drop: ["ALL"]
-    seccompProfile:
-      type: RuntimeDefault
-  resources:
-    limits:
-      {{- if .Values.postgres.cpuLimit }}
-      cpu: {{ .Values.postgres.cpuLimit }}
-      {{- else }}
-      cpu: {{ .Values.postgres.cpu }}
-      {{- end }}
-      memory: "{{ .Values.postgres.memory }}Mi"
-    requests:
-      cpu: {{ .Values.postgres.cpu }}
-      memory: "{{ .Values.postgres.memory }}Mi"
+{{- define "securitycontext" }}
+securityContext:
+  allowPrivilegeEscalation: false
+  runAsNonRoot: true
+  capabilities:
+    drop: ["ALL"]
+  seccompProfile:
+    type: RuntimeDefault
 {{- end }}
 
 {{- define "topologyspreadconstraints" }}
@@ -54,4 +33,115 @@ topologySpreadConstraints:
     labelSelector:
       matchLabels:
         app: {{ .Release.Name }}
+{{- end }}
+
+{{- define "resources" }}
+resources:
+  limits:
+    {{- if .cpuLimit }}
+    cpu: {{ .cpuLimit }}
+    {{- else }}
+    cpu: "{{ printf "%.2f" .cpu | replace "0." "" | replace "." "" | int64 | mul 50 }}m"
+    {{- end }}
+    {{- if .memoryLimit }}
+    memory: "{{ .memoryLimit }}Mi"
+    {{- else }}
+    memory: "{{ (div (mul .memory 6) 5) }}Mi"
+    {{- end }}
+  requests:
+    cpu: {{ .cpu | float64 }}
+    memory: "{{ .memory }}Mi"
+{{- end }}
+
+{{- define "environment" }}
+{{- if .env }}
+env:
+  {{- toYaml .env | nindent 2 }}
+{{ end }}
+{{- if or .envFrom .configmap.enabled .postgres.enabled }}
+envFrom:
+  {{- if .envFrom }}
+  {{- toYaml .envFrom | nindent 2 }}
+  {{- end }}
+  {{- if .configmap.enabled }}
+  - configMapRef:
+      name: {{ .app }}
+  {{- end }}
+  {{- if .postgres.enabled }}
+  - secretRef:
+      name: {{ .app }}-psql-credentials
+  {{- end }}
+{{- end }}
+{{ end }}
+
+{{- define "probes" }}
+livenessProbe:
+  httpGet:
+    path: {{ .probes.liveness.path }}
+    port: {{ .probes.liveness.port | default .internalPort }}
+  failureThreshold: {{ .probes.liveness.failureThreshold | default 6 }}
+  periodSeconds: {{ .probes.liveness.periodSeconds | default 5 }}
+readinessProbe:
+  httpGet:
+    path: {{ .probes.readiness.path }}
+    port: {{ .probes.readiness.port | default .internalPort }}
+  failureThreshold: {{ .probes.liveness.failureThreshold | default 6 }}
+  periodSeconds: {{ .probes.liveness.periodSeconds | default 5 }}
+startupProbe:
+  tcpSocket:
+    port: {{ .probes.startup.port | default .internalPort }}
+  failureThreshold: {{ .probes.startup.failureThreshold | default 300  }}
+  periodSeconds: {{ .probes.startup.periodSeconds | default 1 }}
+{{- end }}
+
+{{- define "grpcprobes" }}
+startupProbe:
+  exec:
+    command: ["/bin/grpc_health_probe", "-addr=:{{ .internalPort }}", "-service=ready"]
+  initialDelaySeconds: 10
+  failureThreshold: 30
+  periodSeconds: 10
+readinessProbe:
+  exec:
+    command: ["/bin/grpc_health_probe", "-addr=:{{ .internalPort }}", "-service=ready"]
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  timeoutSeconds: 5
+livenessProbe:
+  exec:
+    command: ["/bin/grpc_health_probe", "-addr=:{{ .internalPort }}", "-service=health"]
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  timeoutSeconds: 5
+{{- end }}
+
+{{- define "gcloud_sql_proxy" }}
+- name: "{{ .app }}-sql-proxy"
+  image: gcr.io/cloudsql-docker/gce-proxy:1.30.1
+  command:
+    - "/cloud_sql_proxy"
+    - "-verbose=false"
+    - "-log_debug_stdout"
+    - "-term_timeout=30s"
+  envFrom:
+  - configMapRef:
+      name: {{ .app }}-psql-connection
+  securityContext:
+    runAsNonRoot: true
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop: ["ALL"]
+    seccompProfile:
+      type: RuntimeDefault
+  resources:
+    limits:
+      {{- if .postgres.cpuLimit }}
+      cpu: {{ .postgres.cpuLimit }}
+      {{- else }}
+      cpu: {{ .postgres.cpu }}
+      {{- end }}
+      memory: "{{ .postgres.memory }}Mi"
+    requests:
+      cpu: {{ .postgres.cpu }}
+      memory: "{{ .postgres.memory }}Mi"
 {{- end }}

--- a/charts/common/templates/cron.yaml
+++ b/charts/common/templates/cron.yaml
@@ -1,0 +1,71 @@
+{{- /* Rules */}}
+{{- $env := .Values.env | required ".Values.common.env is required." -}}
+{{- $app := .Values.app | required ".Values.common.app is required." -}}
+{{- $shortname := .Values.shortname | required ".Values.common.shortname is required." -}}
+{{- $team := .Values.team | required ".Values.common.team is required." -}}
+
+{{- $containers := .Values.containers | default (list .Values.container) -}}
+{{- $configmap := .Values.configmap -}}
+{{- $postgres := .Values.postgres -}}
+{{- $cronjob := .Values.cron | default (dict
+    "enabled" false
+    "volumes" .Values.container.volumes
+    "labels" .Values.container.labels) -}}
+{{- if $cronjob.enabled -}}
+{{- /* YAML Spec */}}
+apiVersion: apps/v1
+kind: CronJob
+metadata:
+  labels:
+    {{- include "labels" . | indent 4 }}
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  concurrencyPolicy: {{ $cronjob.concurrencyPolicy | default "Forbid" }}
+  failedJobsHistoryLimit: {{ $cronjob.failedJobsHistoryLimit | default 1 }}
+  schedule: {{ $cronjob.schedule | required ".Values.common.cron.schedule is required." }}
+  successfulJobsHistoryLimit: {{ $cronjob.successfulJobsHistoryLimit | default 1 }}
+  suspend: {{ $cronjob.suspend | default false }}
+  jobTemplate:
+    metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+      labels:
+        {{- include "labels" . | indent 8 }}
+        {{- if $cronjob.labels }}
+        {{- toYaml $cronjob.labels | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: application
+
+      containers:
+      {{ range $containers }}
+        {{- $image := .image | required ".Values.common.container.image is required." -}}
+        {{- printf "\n        " -}}
+        - name: {{ .name | default $app }}
+          image: {{ $image }}
+          imagePullPolicy: Always
+          {{- include "environment" (dict "app" $app "env" .env "envFrom" .envFrom "configmap" $configmap "postgres" $postgres) | nindent 10 -}}
+          {{- include "resources" . | nindent 10 }}
+          {{- include "securitycontext" . | nindent 10 }}
+          {{- if .volumeMounts }}
+          volumeMounts:
+            {{- toYaml .volumeMounts | nindent 12 }}
+          {{- end }}
+        {{- if $postgres.enabled }}
+          {{- include "gcloud_sql_proxy" (dict "postgres" $postgres "app" $app) | indent 8 }}
+        {{- end }}
+      {{- end }}
+      {{- if $cronjob.volumes }}
+      volumes:
+        {{- toYaml $cronjob.volumes | nindent 8 }}
+      {{- end }}
+      {{- if .Values.cron.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ .Values.cron.terminationGracePeriodSeconds }}
+      {{- end }}
+      restartPolicy: Always
+      securityContext:
+        runAsGroup: {{ .Values.container.uid }}
+        runAsNonRoot: true
+        runAsUser: {{ .Values.container.uid }}
+{{- end -}}

--- a/charts/common/templates/cron.yaml
+++ b/charts/common/templates/cron.yaml
@@ -7,10 +7,7 @@
 {{- $containers := .Values.containers | default (list .Values.container) -}}
 {{- $configmap := .Values.configmap -}}
 {{- $postgres := .Values.postgres -}}
-{{- $cronjob := .Values.cron | default (dict
-    "enabled" false
-    "volumes" .Values.container.volumes
-    "labels" .Values.container.labels) -}}
+{{- $cronjob := .Values.cron -}}
 {{- if $cronjob.enabled -}}
 {{- /* YAML Spec */}}
 apiVersion: apps/v1

--- a/charts/common/templates/deployment.yaml
+++ b/charts/common/templates/deployment.yaml
@@ -3,9 +3,20 @@
 {{- $app := .Values.app | required ".Values.common.app is required." -}}
 {{- $shortname := .Values.shortname | required ".Values.common.shortname is required." -}}
 {{- $team := .Values.team | required ".Values.common.team is required." -}}
-{{- $image := .Values.container.image | required ".Values.common.container.image is required." -}}
-{{- $replicas := .Values.container.forceReplicas | default .Values.container.replicas -}}
 
+{{- $containers := .Values.containers | default (list .Values.container) -}}
+{{- $configmap := .Values.configmap -}}
+{{- $postgres := .Values.postgres -}}
+{{- $internalPort := .Values.service.internalPort -}}
+{{- $grpc := .Values.grpc -}}
+{{- $labels := .Values.deployment.labels | default .Values.container.labels }}
+{{- $volumes := .Values.deployment.volumes | default .Values.container.volumes }}
+{{- $enabled := .Values.deployment.enabled | default .Values.container.enabled }}
+{{- $prometheus := .Values.deployment.prometheus | default .Values.container.prometheus }}
+{{- $replicas := .Values.deployment.replicas | default .Values.container.replicas }}
+{{- $forceReplicas := .Values.deployment.forceReplicas | default .Values.container.forceReplicas }}
+{{- $terminationGracePeriodSeconds := .Values.deployment.terminationGracePeriodSeconds | default .Values.container.terminationGracePeriodSeconds }}
+{{- if $enabled }}
 {{- /* YAML Spec */}}
 apiVersion: apps/v1
 kind: Deployment
@@ -18,9 +29,13 @@ spec:
   selector:
     matchLabels:
       app: {{ .Release.Name }}
+  {{- if $forceReplicas }}
+  replicas: {{ $forceReplicas }}
+  {{- else }}
   replicas: {{ $replicas }}
+  {{- end }}
   strategy:
-    {{- if (eq (int .Values.container.forceReplicas) 1) }}
+    {{- if (eq (int $forceReplicas) 1) }}
     type: Recreate
     {{- else }}
     type: RollingUpdate
@@ -29,121 +44,60 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
-        {{- if .Values.container.prometheus.enabled }}
+        {{- if (($prometheus).enabled) }}
         prometheus.io/scrape: "true"
-        prometheus.io/path: "{{ .Values.container.prometheus.path }}"
-        prometheus.io/port: "{{ .Values.service.internalPort }}"
+        prometheus.io/path: "{{ $prometheus.path }}"
+        prometheus.io/port: "{{ $prometheus.port | default .Values.service.internalPort | required "Must set deployment.prometheus.port" }}"
         {{- end }}
       labels:
         {{- include "labels" . | indent 8 }}
-        {{- if .Values.container.labels }}
-        {{- toYaml .Values.container.labels | nindent 8 }}
+        {{- if $labels }}
+        {{- toYaml $labels | nindent 8 }}
         {{- end }}
     spec:
       serviceAccountName: application
 
       containers:
-        - name: {{ .Values.app }}
+      {{ range $containers }}
+        {{- $image := .image | required ".Values.common.container.image is required." -}}
+        {{- printf "\n        " -}}
+        - name: {{ .name | default $app }}
           image: {{ $image }}
           imagePullPolicy: Always
-          {{- if .Values.container.env }}
-          env:
-            {{- toYaml .Values.container.env | nindent 12 }}
-          {{- end }}
-          {{- if or .Values.container.envFrom .Values.configmap.enabled .Values.postgres.enabled }}
-          envFrom:
-            {{- if .Values.container.envFrom }}
-            {{- toYaml .Values.container.envFrom | nindent 12 }}
-            {{- end }}
-            {{- if .Values.configmap.enabled }}
-            - configMapRef:
-                name: {{ .Release.Name }}
-            {{- end }}
-            {{- if .Values.postgres.enabled }}
-            - secretRef:
-                name: {{ .Values.app }}-psql-credentials
-            {{- end }}
-          {{- end }}
+          {{- include "environment" (dict "app" $app "env" .env "envFrom" .envFrom "configmap" $configmap "postgres" $postgres) | nindent 10 -}}
           ports:
-            - containerPort: {{ .Values.service.internalPort }}
+            {{- if .ports }}
+              {{- toYaml .ports | nindent 12 }}
+            {{- else }}
+            - containerPort: {{ $internalPort }}
               protocol: TCP
-          resources:
-            limits:
-              {{- if .Values.container.cpuLimit }}
-              cpu: {{ .Values.container.cpuLimit }}
-              {{- else }}
-              cpu: "{{ printf "%.2f" .Values.container.cpu | replace "0." "" | replace "." "" | int64 | mul 50 }}m"
-              {{- end }}
-              {{- if .Values.container.memoryLimit }}
-              memory: "{{ .Values.container.memoryLimit }}Mi"
-              {{- else }}
-              memory: "{{ (div (mul .Values.container.memory 6) 5) }}Mi" # TODO: same as above, fix when mulf is working
-              {{- end }}
-            requests:
-              cpu: {{ .Values.container.cpu | float64 }}
-              memory: "{{ .Values.container.memory }}Mi"
-          securityContext:
-            allowPrivilegeEscalation: false
-            runAsNonRoot: true
-            capabilities:
-              drop: ["ALL"]
-            seccompProfile:
-              type: RuntimeDefault
-          {{- if .Values.grpc }}
-          startupProbe:
-            exec:
-              command: ["/bin/grpc_health_probe", "-addr=:{{ .Values.service.internalPort }}", "-service=ready"]
-            initialDelaySeconds: 10
-            failureThreshold: 30
-            periodSeconds: 10
-          readinessProbe:
-            exec:
-              command: ["/bin/grpc_health_probe", "-addr=:{{ .Values.service.internalPort }}", "-service=ready"]
-            initialDelaySeconds: 10
-            periodSeconds: 10
-            timeoutSeconds: 5
-          livenessProbe:
-            exec:
-              command: ["/bin/grpc_health_probe", "-addr=:{{ .Values.service.internalPort }}", "-service=health"]
-            initialDelaySeconds: 10
-            periodSeconds: 10
-            timeoutSeconds: 5
+            {{- end }}
+          {{- include "resources" . | nindent 10 }}
+          {{- include "securitycontext" . | nindent 10 }}
+          {{- if or $grpc .grpc }}
+            {{- include "grpcprobes" (dict "internalPort" $internalPort) | nindent 10 -}}
           {{- else }}
-          livenessProbe:
-            httpGet:
-              path: {{ .Values.container.probes.liveness.path }}
-              port: {{ .Values.service.internalPort }}
-            failureThreshold: {{ .Values.container.probes.liveness.failureThreshold }}
-            periodSeconds: {{ .Values.container.probes.liveness.periodSeconds }}
-          readinessProbe:
-            httpGet:
-              path: {{ .Values.container.probes.readiness.path }}
-              port: {{ .Values.service.internalPort }}
-            failureThreshold: {{ .Values.container.probes.liveness.failureThreshold }}
-            periodSeconds: {{ .Values.container.probes.liveness.periodSeconds }}
-          startupProbe:
-            tcpSocket:
-              port: {{ .Values.service.internalPort }}
-            failureThreshold: {{ .Values.container.probes.startup.failureThreshold }}
-            periodSeconds: {{ .Values.container.probes.startup.periodSeconds }}
+            {{- include "probes" (dict "internalPort" $internalPort "probes" .probes) | nindent 10 -}}
           {{ end }}
-          {{- if .Values.container.volumeMounts }}
+          {{- if .volumeMounts }}
           volumeMounts:
-            {{- toYaml .Values.container.volumeMounts | nindent 12 }}
+            {{- toYaml .volumeMounts | nindent 12 }}
           {{- end }}
-        {{- if .Values.postgres.enabled }}
-        {{- include "gcloud_sql_proxy" . | indent 8 }}
+        {{- if $postgres.enabled }}
+          {{- include "gcloud_sql_proxy" (dict "postgres" $postgres "app" $app) | indent 8 }}
         {{- end }}
-      {{- if .Values.container.volumes }}
+      {{- end }}
+      {{- if $volumes }}
       volumes:
-        {{- toYaml .Values.container.volumes | nindent 8 }}
+        {{- toYaml $volumes | nindent 8 }}
       {{- end }}
       {{- include "topologyspreadconstraints" . | indent 6 }}
-      {{- if .Values.container.terminationGracePeriodSeconds }}
-      terminationGracePeriodSeconds: {{ .Values.container.terminationGracePeriodSeconds }}
+      {{- if $terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ $terminationGracePeriodSeconds }}
       {{- end }}
       restartPolicy: Always
       securityContext:
         runAsGroup: {{ .Values.container.uid }}
         runAsNonRoot: true
         runAsUser: {{ .Values.container.uid }}
+{{- end }}

--- a/charts/common/templates/hpa.yaml
+++ b/charts/common/templates/hpa.yaml
@@ -30,12 +30,12 @@ spec:
       target:
         type: Utilization
         averageUtilization: {{ $cpuUtilization }}
+  maxReplicas: {{ $maxReplicas }}
+  minReplicas: {{ max 2 .Values.container.replicas }}
   {{- end }}
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
     name: {{ .Release.Name }}
-  maxReplicas: {{ $maxReplicas }}
-  minReplicas: {{ max 2 .Values.container.replicas }}
 {{- end }}
 {{- end }}

--- a/charts/common/templates/hpa.yaml
+++ b/charts/common/templates/hpa.yaml
@@ -4,7 +4,7 @@
 {{- if (and (not .Values.container.forceReplicas) (or (eq "prd" .Values.env) .Values.container.maxReplicas)) }}
   {{- /* Defaults */}}
   {{- $maxReplicas := .Values.container.maxReplicas | default 10 }}
-  {{- $cpuUtilization := 80 }}
+  {{- $cpuUtilization := 100 }}
 
   {{- /* Rules */}}
   {{- if (eq 1 (int $maxReplicas)) }}
@@ -12,7 +12,7 @@
   {{- else }}
 
 {{- /* YAML Spec */}}
-apiVersion: autoscaling/v1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ .Release.Name }}
@@ -20,12 +20,22 @@ metadata:
   labels:
     {{- include "labels" . | indent 4 }}
 spec:
-  maxReplicas: {{ $maxReplicas }}
-  minReplicas: {{ max 2 .Values.container.replicas }}
+  {{- if ((.Values.hpa).spec) }}
+  {{ toYaml .Values.hpa.spec | nindent 2 }}
+  {{- else }}
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: {{ $cpuUtilization }}
+  {{- end }}
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
     name: {{ .Release.Name }}
-  targetCPUUtilizationPercentage: {{ $cpuUtilization }}
+  maxReplicas: {{ $maxReplicas }}
+  minReplicas: {{ max 2 .Values.container.replicas }}
 {{- end }}
 {{- end }}

--- a/charts/common/templates/ingress.yaml
+++ b/charts/common/templates/ingress.yaml
@@ -34,6 +34,9 @@ spec:
                   number: {{ $externalPort }}
             pathType: ImplementationSpecific
     {{- end }}
----
+
+# Must manually print newlines for unittest, do not remove
+{{ print "\n---\n" }}
+
 {{- end }}
 {{- end }}

--- a/charts/common/templates/ingress.yaml
+++ b/charts/common/templates/ingress.yaml
@@ -1,28 +1,39 @@
-{{- if .Values.ingress.enabled }}
+{{- if or .Values.ingresses .Values.ingress.enabled }}
   {{- /* Rules */}}
-  {{- $checkHost := .Values.ingress.host | required ".Values.common.ingress.host is required." -}}
-  {{- $checkTrafficType := .Values.ingress.trafficType | required ".Values.common.ingress.trafficType is required." -}}
+  {{- $externalPort :=  .Values.service.externalPort  -}}
+  {{- $chart := . -}}
+  {{- $releaseName := .Release.Name -}}
+  {{- $releaseNamespace := .Release.Namespace -}}
+  {{- $ingresses := .Values.ingresses | default (list .Values.ingress) -}}
 
 {{- /* YAML Spec */}}
+{{ range $ingresses }}
+{{- $checkTrafficType := .trafficType | required "ingress.trafficType is required." -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
     kubernetes.io/ingress.class: traefik
   labels:
-    traffic-type: {{ .Values.ingress.trafficType }}
-    {{- include "labels" . | indent 4 }}
-  name: {{ .Release.Name }}
-  namespace: {{ .Release.Namespace }}
+    traffic-type: {{ .trafficType }}
+    {{- include "labels" $chart | indent 4 }}
+  name: {{ .name | default $releaseName }}
+  namespace: {{ $releaseNamespace }}
 spec:
   rules:
-    - host: {{ .Values.ingress.host }}
+    {{- if .rules -}}
+    {{ toYaml .rules | nindent 4 }}
+    {{- else }}
+    - host: {{ .host | required ".Values.common.ingress.host is required." }}
       http:
         paths:
           - backend:
               service:
-                name: {{ .Release.Name }}
+                name: {{ $releaseName }}
                 port:
-                  number: {{ .Values.service.externalPort }}
+                  number: {{ $externalPort }}
             pathType: ImplementationSpecific
+    {{- end }}
+---
+{{- end }}
 {{- end }}

--- a/charts/common/templates/pdb.yaml
+++ b/charts/common/templates/pdb.yaml
@@ -6,9 +6,6 @@
     {{ $checkReplicas := .Values.error | required ".Values.common.container.replicas must be greater than 1 when using minAvailable" }}
   {{- end }}
 
-  {{- /* Defaults */}}
-  {{- $minAvailable := .Values.container.minAvailable | default "50%" }}
-
 {{- /* YAML Spec */}}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
@@ -18,7 +15,13 @@ metadata:
   labels:
     {{- include "labels" . | indent 4 }}
 spec:
-  minAvailable: {{ $minAvailable }}
+  {{- if ((.Values.pdb).minAvailable) }}
+  minAvailable: {{ .Values.pdb.minAvailable }}
+  {{- else if ((.Values.container).minAvailable) }}
+  minAvailable: {{ .Values.container.minAvailable }}
+  {{- else }}
+  minAvailable: 50%
+  {{- end }}
   selector:
     matchLabels:
       app: {{ .Release.Name }}

--- a/charts/common/templates/service.yaml
+++ b/charts/common/templates/service.yaml
@@ -12,10 +12,14 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   ports:
+  {{- if .Values.service.ports }}
+  {{- toYaml .Values.service.ports | nindent 4 }}
+  {{- else }}
   - name: http
     port: {{ .Values.service.externalPort }}
     protocol: TCP
     targetPort: {{ .Values.service.internalPort }}
+  {{- end }}
   selector:
     app: {{ .Release.Name }}
   type: ClusterIP

--- a/charts/common/tests/cron_test.yaml
+++ b/charts/common/tests/cron_test.yaml
@@ -1,0 +1,197 @@
+probes: &probes
+      probes:
+        liveness:
+          path: "/actuator/health/liveness"
+        readiness:
+          path: "/actuator/health/readiness"
+        startup:
+          failureThreshold: 300
+          periodSeconds: 1
+
+values: &values
+  env: dev
+  app: testsuite
+  shortname: tstsut
+  team: common
+  ingress:
+    host: test.dev.entur.io
+    trafficType: public
+  labels:
+    custom: label
+  deployment: 
+    enabled: false
+  cron:
+    enabled: true
+    schedule: "30 04 * ? *"
+    labels:
+      version: 1
+  containers:
+    - name: test
+      image: img
+      env:
+        - FOO: bar
+      <<: *probes
+
+
+suite: test deployment
+templates:
+  - cron.yaml
+tests:
+  - it: must have labels
+    set:
+      <<: *values
+    asserts:
+      - isNotEmpty:
+          template: cron.yaml
+          path: metadata.labels
+      - isNotEmpty:
+          template: cron.yaml
+          path: metadata.labels.environment
+      - isNotEmpty:
+          template: cron.yaml
+          path: metadata.labels.custom
+      - isNotEmpty:
+          template: cron.yaml
+          path: spec.jobTemplate.metadata.labels.common
+  - it: must add to env if listed
+    set:
+      <<: *values
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.containers[0].env[0].FOO
+          value: bar
+  - it: cpu limit can be overridden
+    release:
+    set:
+      <<: *values
+      containers:
+        - name: test
+          image: img
+          cpu: 0.1
+          cpuLimit: 1
+          <<: *probes
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.containers[0].resources.limits.cpu
+          value: 1
+      - equal:
+          path: spec.jobTemplate.spec.containers[0].resources.requests.cpu
+          value: 0.1
+  - it: cpu limit is 5x request for 0.1
+    release:
+    set:
+      <<: *values
+      containers:
+        - name: test
+          image: img
+          cpu: 0.1
+          <<: *probes
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.containers[0].resources.limits.cpu
+          value: 500m
+      - equal:
+          path: spec.jobTemplate.spec.containers[0].resources.requests.cpu
+          value: 0.1
+  - it: cpu limit is 5x request for 0.75
+    release:
+    set:
+      <<: *values
+      containers:
+        - name: test
+          image: img
+          cpu: 0.75
+          <<: *probes
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.containers[0].resources.limits.cpu
+          value: 3750m
+      - equal:
+          path: spec.jobTemplate.spec.containers[0].resources.requests.cpu
+          value: 0.75
+  - it: cpu limit is 5x request for 1
+    release:
+    set:
+      <<: *values
+      containers:
+        - name: test
+          image: img
+          cpu: 1.0
+          <<: *probes
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.containers[0].resources.limits.cpu
+          value: 5000m
+      - equal:
+          path: spec.jobTemplate.spec.containers[0].resources.requests.cpu
+          value: 1
+  - it: cpu limit is 5x request for > 1
+    release:
+    set:
+      <<: *values
+      containers:
+        - name: test
+          image: img
+          cpu: 2.1
+          <<: *probes
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.containers[0].resources.limits.cpu
+          value: 10500m
+      - equal:
+          path: spec.jobTemplate.spec.containers[0].resources.requests.cpu
+          value: 2.1
+  - it: memory limit is 120 percent of request
+    release:
+    set:
+      <<: *values
+      containers:
+        - name: test
+          image: img
+          memory: 256
+          <<: *probes
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.containers[0].resources.limits.memory
+          value: 307Mi
+      - equal:
+          path: spec.jobTemplate.spec.containers[0].resources.requests.memory
+          value: 256Mi
+  - it: memory limit can be overridden
+    release:
+    set:
+      <<: *values
+      containers:
+        - name: test
+          image: img
+          memory: 256
+          memoryLimit: 1024
+          <<: *probes
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.containers[0].resources.limits.memory
+          value: 1024Mi
+      - equal:
+          path: spec.jobTemplate.spec.containers[0].resources.requests.memory
+          value: 256Mi
+  - it: terminationGracePeriodSeconds use correct value
+    set:
+      <<: *values
+      cron:
+        enabled: true
+        schedule: "30 04 * ? *"
+        labels:
+          version: 1
+        terminationGracePeriodSeconds: 60
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.terminationGracePeriodSeconds
+          value: 60
+  - it: spec does not contain terminationGracePeriodSeconds if missing from values
+    set:
+      <<: *values
+    asserts:
+      - isEmpty:
+          path: spec.jobTemplate.spec.terminationGracePeriodSeconds
+
+

--- a/charts/common/tests/deployment_v1_test.yaml
+++ b/charts/common/tests/deployment_v1_test.yaml
@@ -1,13 +1,3 @@
-probes: &probes
-      probes:
-        liveness:
-          path: "/actuator/health/liveness"
-        readiness:
-          path: "/actuator/health/readiness"
-        startup:
-          failureThreshold: 300
-          periodSeconds: 1
-
 values: &values
   env: dev
   app: testsuite
@@ -16,18 +6,8 @@ values: &values
   ingress:
     host: test.dev.entur.io
     trafficType: public
-  labels:
-    custom: label
-  deployment:
-    labels:
-      version: 1
-  containers:
-    - name: test
-      image: img
-      env:
-        - FOO: bar
-      <<: *probes
-
+  container:
+    image: img
 
 suite: test deployment
 templates:
@@ -36,6 +16,12 @@ tests:
   - it: must have labels
     set:
       <<: *values
+      labels:
+        custom: label
+      container:
+        image: img
+        labels:
+          version: 1
     asserts:
       - isNotEmpty:
           template: deployment.yaml
@@ -52,20 +38,35 @@ tests:
   - it: must add to env if listed
     set:
       <<: *values
+      container:
+        image: img
+        env:
+          - FOO: bar
     asserts:
       - equal:
           path: spec.template.spec.containers[0].env[0].FOO
           value: bar
+  - it: must mount envFrom if configmap is enabled
+    release:
+      name: testsuite
+    set:
+      <<: *values
+      configmap:
+        enabled: true
+        data:
+          FOO: bar
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].envFrom[0].configMapRef.name
+          value: testsuite
   - it: cpu limit can be overridden
     release:
     set:
       <<: *values
-      containers:
-        - name: test
-          image: img
-          cpu: 0.1
-          cpuLimit: 1
-          <<: *probes
+      container:
+        image: img
+        cpu: 0.1
+        cpuLimit: 1
     asserts:
       - equal:
           path: spec.template.spec.containers[0].resources.limits.cpu
@@ -77,11 +78,9 @@ tests:
     release:
     set:
       <<: *values
-      containers:
-        - name: test
-          image: img
-          cpu: 0.1
-          <<: *probes
+      container:
+        image: img
+        cpu: 0.1
     asserts:
       - equal:
           path: spec.template.spec.containers[0].resources.limits.cpu
@@ -93,11 +92,9 @@ tests:
     release:
     set:
       <<: *values
-      containers:
-        - name: test
-          image: img
-          cpu: 0.75
-          <<: *probes
+      container:
+        image: img
+        cpu: 0.75
     asserts:
       - equal:
           path: spec.template.spec.containers[0].resources.limits.cpu
@@ -109,11 +106,9 @@ tests:
     release:
     set:
       <<: *values
-      containers:
-        - name: test
-          image: img
-          cpu: 1.0
-          <<: *probes
+      container:
+        image: img
+        cpu: 1.0
     asserts:
       - equal:
           path: spec.template.spec.containers[0].resources.limits.cpu
@@ -125,11 +120,9 @@ tests:
     release:
     set:
       <<: *values
-      containers:
-        - name: test
-          image: img
-          cpu: 2.1
-          <<: *probes
+      container:
+        image: img
+        cpu: 2.1
     asserts:
       - equal:
           path: spec.template.spec.containers[0].resources.limits.cpu
@@ -141,11 +134,9 @@ tests:
     release:
     set:
       <<: *values
-      containers:
-        - name: test
-          image: img
-          memory: 256
-          <<: *probes
+      container:
+        image: img
+        memory: 256
     asserts:
       - equal:
           path: spec.template.spec.containers[0].resources.limits.memory
@@ -157,12 +148,10 @@ tests:
     release:
     set:
       <<: *values
-      containers:
-        - name: test
-          image: img
-          memory: 256
-          memoryLimit: 1024
-          <<: *probes
+      container:
+        image: img
+        memory: 256
+        memoryLimit: 1024
     asserts:
       - equal:
           path: spec.template.spec.containers[0].resources.limits.memory
@@ -173,10 +162,10 @@ tests:
   - it: must enable prometheus if enabled
     set:
       <<: *values
-      deployment:
+      container:
+        image: img
         prometheus:
           enabled: true
-          path: /actuator/prometheus
     asserts:
       - equal:
           path: spec.template.metadata.annotations
@@ -185,11 +174,47 @@ tests:
             prometheus.io/scrape: "true"
             prometheus.io/path: "/actuator/prometheus"
             prometheus.io/port: "8080"
+  - it: must mount envFrom if postgres enabled
+    set:
+      <<: *values
+      postgres:
+        enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].envFrom[0].secretRef.name
+          value: testsuite-psql-credentials
+  - it: must enable sidecar if postgres enabled
+    set:
+      <<: *values
+      postgres:
+        enabled: true
+    asserts:
+      - isNotEmpty:
+          path: spec.template.spec.containers[1]
+      - equal:
+          path: spec.template.spec.containers[1].envFrom[0].configMapRef.name
+          value: testsuite-psql-connection
+  - it: postgres cpu limit can be overridden
+    release:
+    set:
+      <<: *values
+      postgres:
+        enabled: true
+        cpu: 0.1
+        cpuLimit: 1
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[1].resources.limits.cpu
+          value: 1
+      - equal:
+          path: spec.template.spec.containers[1].resources.requests.cpu
+          value: 0.1
   - it: must use 3 replicas if replicas is 3
     set:
       <<: *values
       env: dev
-      deployment:
+      container:
+        image: testimg
         replicas: 3
     asserts:
       - equal:
@@ -202,7 +227,8 @@ tests:
     set:
       <<: *values
       env: prd
-      deployment:
+      container:
+        image: some
         forceReplicas: 1
     asserts:
       - equal:
@@ -215,7 +241,8 @@ tests:
     set:
       <<: *values
       env: prd
-      deployment:
+      container:
+        image: some
         forceReplicas: 3
     asserts:
       - equal:
@@ -227,18 +254,9 @@ tests:
   - it: must adopt for gRPC
     set:
       <<: *values
-      containers:
-        - name: test
-          image: img
-          grpc: true
-          probes:
-            liveness:
-              path: "/actuator/health/liveness"
-            readiness:
-              path: "/actuator/health/readiness"
-            startup:
-              failureThreshold: 300
-              periodSeconds: 1
+      grpc: true
+      container:
+        image: img
     asserts:
       - isNotEmpty:
           template: deployment.yaml
@@ -246,7 +264,8 @@ tests:
   - it: terminationGracePeriodSeconds use correct value
     set:
       <<: *values
-      deployment:
+      container:
+        image: img
         terminationGracePeriodSeconds: 60
     asserts:
       - equal:
@@ -255,6 +274,8 @@ tests:
   - it: spec does not contain terminationGracePeriodSeconds if missing from values
     set:
       <<: *values
+      container:
+        image: img
     asserts:
       - isEmpty:
           path: spec.template.spec.terminationGracePeriodSeconds

--- a/charts/common/tests/hpa_test.yaml
+++ b/charts/common/tests/hpa_test.yaml
@@ -71,9 +71,16 @@ tests:
       env: prd
       hpa:
         spec:
-          metrics: []
+          metrics:
+          - type: Resource
+            resource:
+              name: cpu
+              target:
+                type: Utilization
+                averageUtilization: 200
     asserts:
       - isNotEmpty:
           path: spec.scaleTargetRef
-      - isEmpty:
-          path: spec.metrics
+      - equal:
+          path: spec.metrics[0].resource.target.averageUtilization
+          value: 200

--- a/charts/common/tests/hpa_test.yaml
+++ b/charts/common/tests/hpa_test.yaml
@@ -65,3 +65,15 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
+  - it: must have scaleTargetRef even if spec is given
+    set:
+      <<: *values
+      env: prd
+      hpa:
+        spec:
+          metrics: []
+    asserts:
+      - isNotEmpty:
+          path: spec.scaleTargetRef
+      - isEmpty:
+          path: spec.metrics

--- a/charts/common/tests/hpa_test.yaml
+++ b/charts/common/tests/hpa_test.yaml
@@ -39,8 +39,8 @@ tests:
         maxReplicas: 5
     asserts:
       - equal:
-          path: spec.targetCPUUtilizationPercentage
-          value: 80
+          path: spec.metrics[0].resource.target.averageUtilization
+          value: 100
   - it: must default for prd
     set:
       <<: *values

--- a/charts/common/tests/ingress_test.yaml
+++ b/charts/common/tests/ingress_test.yaml
@@ -121,20 +121,21 @@ tests:
                           number: 666
                     pathType: ImplementationSpecific
     asserts:
+      - hasDocuments:
+          count: 2
       - equal:
           path: spec.rules[0].http.paths[0].backend.service.port.number
           value: 777
-        template: ingress.yaml
-        documentIndex: 1
+        documentIndex: 0
       - equal:
           path: spec.rules[0].host
           value: good.io
-        documentIndex: 1
+        documentIndex: 0
       - equal:
           path: spec.rules[0].http.paths[0].backend.service.port.number
           value: 666
-        documentIndex: 0
+        documentIndex: 1
       - equal:
           path: spec.rules[0].host
           value: bad.io
-        documentIndex: 0
+        documentIndex: 1

--- a/charts/common/tests/ingress_test.yaml
+++ b/charts/common/tests/ingress_test.yaml
@@ -48,3 +48,93 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
+  - it: can be custom
+    set:
+      <<: *values
+      ingress:
+        enabled: true
+        trafficType: public
+        rules:
+          - host: good.io
+            http:
+              paths:
+                - backend:
+                    service:
+                      name: something
+                      port:
+                        number: 777
+                  pathType: ImplementationSpecific
+          - host: bad.io
+            http:
+              paths:
+                - backend:
+                    service:
+                      name: something
+                      port:
+                        number: 666
+                  pathType: ImplementationSpecific
+    asserts:
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.port.number
+          value: 777
+      - equal:
+          path: spec.rules[0].host
+          value: good.io
+      - equal:
+          path: spec.rules[1].http.paths[0].backend.service.port.number
+          value: 666
+      - equal:
+          path: spec.rules[1].host
+          value: bad.io
+  - it: can be multiple custom
+    set:
+      env: dev
+      app: testsuite
+      shortname: tstsut
+      team: common
+      service:
+        externalPort: 8080
+        internalPort: 8080
+      container:
+        image: img
+      ingresses:
+        - trafficType: public
+          rules:
+            - host: good.io
+              http:
+                paths:
+                  - backend:
+                      service:
+                        name: something
+                        port:
+                          number: 777
+                    pathType: ImplementationSpecific
+        - trafficType: api
+          rules:
+            - host: bad.io
+              http:
+                paths:
+                  - backend:
+                      service:
+                        name: something
+                        port:
+                          number: 666
+                    pathType: ImplementationSpecific
+    asserts:
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.port.number
+          value: 777
+        template: ingress.yaml
+        documentIndex: 1
+      - equal:
+          path: spec.rules[0].host
+          value: good.io
+        documentIndex: 1
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.port.number
+          value: 666
+        documentIndex: 0
+      - equal:
+          path: spec.rules[0].host
+          value: bad.io
+        documentIndex: 0

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -42,18 +42,18 @@ deployment:
 cron:
   # -- Enable or disable the cron job
   enabled: true
-  # -- Concurrency policy, default `Forbid`
+  # -- Concurrency policy
   # @default -- Forbid
   concurrencyPolicy:
-  # -- (int) Failed jobs history limit, default 1
+  # -- (int) Failed jobs history limit
   # @default -- 1
   failedJobsHistoryLimit:
   # -- Required crontab schedule `* * * * * *`
   schedule:
-  # -- (int) Successful jobs history limit, default 1
+  # -- (int) Successful jobs history limit
   # @default -- 1
   successfulJobsHistoryLimit:
-  # -- Suspend flag, default `false`
+  # -- Suspend flag
   # @default -- false
   suspend:
   # -- Add labels to your pods
@@ -68,6 +68,11 @@ hpa:
   #spec:
     #metrics: ...
     #behaviour: ...
+
+pdb:
+  # -- (string) Set minimum available %
+  # @default -- 50%
+  minAvailable:
 
 service:
   # -- Enable or disable the service

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -25,6 +25,49 @@ grpc: false
 deployment:
   # -- Enable or disable the deployment
   enabled: true
+  # -- Add labels to your pods
+  labels: {}
+  # -- Configure volume, accepts kubernetes syntax
+  volumes: []
+  # -- Prometheus
+  #prometheus: same as container.prometheus stanza
+  # -- Set the target replica count
+  # @default -- container.replicas
+  replicas: 
+  # -- (int) Force replicas disables autoscaling, if set to 1 it will use Recreate strategy
+  forceReplicas:
+  # -- (int) Override pod terminationGracePeriodSeconds (default 30s).
+  terminationGracePeriodSeconds:
+
+cron:
+  # -- Enable or disable the cron job
+  enabled: true
+  # -- Concurrency policy, default `Forbid`
+  # @default -- Forbid
+  concurrencyPolicy:
+  # -- (int) Failed jobs history limit, default 1
+  # @default -- 1
+  failedJobsHistoryLimit:
+  # -- Required crontab schedule `* * * * * *`
+  schedule:
+  # -- (int) Successful jobs history limit, default 1
+  # @default -- 1
+  successfulJobsHistoryLimit:
+  # -- Suspend flag, default `false`
+  # @default -- false
+  suspend:
+  # -- Add labels to your pods
+  labels: {}
+  # -- Configure volume, accepts kubernetes syntax
+  volumes: []
+  # -- (int) Override pod terminationGracePeriodSeconds (default 30s).
+  # @default -- false
+  terminationGracePeriodSeconds:
+
+hpa:
+  #spec:
+    #metrics: ...
+    #behaviour: ...
 
 service:
   # -- Enable or disable the service
@@ -36,7 +79,13 @@ service:
   # @default -- 8080
   internalPort: 8080
 
+# -- Takes a list of `container` entries, you must add a `name` field for each entry
+containers: []
+
 container:
+  # -- Name of container
+  # @default -- .app
+  name:
   # -- Add labels to your pods
   labels: {}
   # -- Set CPU without any unit. 100m is 0.1
@@ -80,6 +129,9 @@ container:
     # -- Set the path for scraping metrics
     # @default -- /actuator/prometheus
     path: "/actuator/prometheus"
+    # -- (int) Set the port for prometheus scraping
+    # @default -- service.internalPort
+    port: 
   probes:
     liveness:
       # -- Set the path for liveness probe
@@ -109,9 +161,9 @@ container:
       # @default -- 1
       periodSeconds: 1
   # -- Configure volume mounts, accepts kubernetes syntax
-  volumeMounts: {}
+  volumeMounts: []
   # -- Configure volume, accepts kubernetes syntax
-  volumes: {}
+  volumes: []
   # -- (int) Override pod terminationGracePeriodSeconds (default 30s).
   terminationGracePeriodSeconds:
 

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -20,7 +20,8 @@ ingress:
   trafficType:
   # rules: # k8s spec for ingress rules
 
-#ingresses: [] # list of ingress specs
+# -- Specify a list of `ingress` stanzas
+ingresses: [] # list of ingress specs
 
 # -- Enable gRPC which will add an annotation and use grpc probes
 grpc: false
@@ -68,7 +69,8 @@ cron:
   terminationGracePeriodSeconds:
 
 hpa:
-  #spec:
+  # -- Custom spec for HPA, inherits `scaleTargetRef` and min/max replicas.
+  spec:
     #metrics: ...
     #behaviour: ...
 

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -41,7 +41,7 @@ deployment:
 
 cron:
   # -- Enable or disable the cron job
-  enabled: true
+  enabled: false
   # -- Concurrency policy
   # @default -- Forbid
   concurrencyPolicy:

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -22,6 +22,10 @@ ingress:
 # -- Enable gRPC which will add an annotation and use grpc probes
 grpc: false
 
+deployment:
+  # -- Enable or disable the deployment
+  enabled: true
+
 service:
   # -- Enable or disable the service
   enabled: true

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -18,6 +18,9 @@ ingress:
   host:
   # -- Set the traffic type, typically `api` or `public`
   trafficType:
+  # rules: # k8s spec for ingress rules
+
+#ingresses: [] # list of ingress specs
 
 # -- Enable gRPC which will add an annotation and use grpc probes
 grpc: false

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -20,11 +20,14 @@ ingress:
   trafficType:
   # rules: # k8s spec for ingress rules
 
-# -- Specify a list of `ingress` stanzas
-ingresses: [] # list of ingress specs
+# -- Specify a list of `ingress` specs
+ingresses: []
 
 # -- Enable gRPC which will add an annotation and use grpc probes
 grpc: false
+
+# -- Specify a list of `deployment` specs
+deployments: []
 
 deployment:
   # -- Enable or disable the deployment


### PR DESCRIPTION
```yaml
deployment:
  enabled: false
cron:
  enabled: true
  schedule: '30 04 * ? *'

containers:
  - image: ${artifact.metadata.image}
```

New API: 

```yaml
app: mytest
shortname: mytst
team: team

env: prd

ingress:
  host: mytest.dev.entur.io
  trafficType: api

service:
  ports:
    - protocol: TCP
      port: 80
      targetPort: 8080

pdb:
  minAvailable: 25%

hpa:
  spec:
    metrics:
      - type: Resource
        resource:
          name: cpu
          target:
            type: Utilization
            averageUtilization: 80
    behavior:
      scaleDown:
        stabilizationWindowSeconds: 300
        policies:
          - type: Pods
            value: 1
            periodSeconds: 15
      scaleUp:
        stabilizationWindowSeconds: 60
        policies:
          - type: Pods
            value: 2
            periodSeconds: 15

deployment:
  replicas: 1
  labels:
    hello: yes
  prometheus:
    enabled: true
    path: /promhey
    port: 999

postgres:
  enabled: true

#container:
containers:
  - name: ngin1
    image: nginxinc/nginx-unprivileged:latest
    grpc: true
    cpu: 1.1
    cpuLimit: 2.0
    memory: 512
    memoryLimit: 1024
    probes:
      liveness:
        path: "/actuator/health/liveness"
      readiness:
        path: "/actuator/health/readiness"
      startup:
        failureThreshold: 300
    ports:
      - containerPort: 8080
        name: http
        protocol: TCP
      - containerPort: 8778
        name: jolokia
        protocol: TCP
  - name: ngin2
    image: nginxinc/nginx:latest
    cpu: 2.0
    memory: 512
    env:
      - name: hey
        value: yo
    envFrom:
      - configMapRef:
          name: yolo
    probes:
      liveness:
        path: "/actuator/health/liveness"
      readiness:
        path: "/actuator/health/readiness"
      startup:
        failureThreshold: 300
```