### PR TITLE
fix: Wrong apiVersion for the CronJob resource

### DIFF
--- a/charts/common/templates/cron.yaml
+++ b/charts/common/templates/cron.yaml
@@ -11,7 +11,7 @@
 {{- $cronjob := .Values.cron -}}
 {{- if $cronjob.enabled -}}
 {{- /* YAML Spec */}}
-apiVersion: apps/v1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   labels:


### PR DESCRIPTION
The CronJob resource refers to the wrong apiVersion. Still trying to figure out how the tests for this resource are able to pass...