### PR TITLE
fix: Add missing template block in CronJob template

### DIFF
--- a/charts/common/templates/cron.yaml
+++ b/charts/common/templates/cron.yaml
@@ -34,42 +34,42 @@ spec:
         {{- toYaml $cronjob.labels | nindent 8 }}
         {{- end }}
     spec:
-      serviceAccountName: application
-
-      containers:
-      {{ range $containers }}
-        {{- $image := .image | required ".Values.common.container.image is required." -}}
-        {{- printf "\n        " -}}
-        - name: {{ .name | default $app }}
-          image: {{ $image }}
-          imagePullPolicy: Always
-          {{- if .command }}
-          command: {{ .command }}
+      template:
+        serviceAccountName: application
+        containers:
+        {{ range $containers }}
+          {{- $image := .image | required ".Values.common.container.image is required." -}}
+          {{- printf "\n        " -}}
+          - name: {{ .name | default $app }}
+            image: {{ $image }}
+            imagePullPolicy: Always
+            {{- if .command }}
+            command: {{ .command }}
+            {{- end }}
+            {{- if .args }}
+            args: {{ toYaml .args | nindent 10 }}
+            {{- end }}
+            {{- include "environment" (dict "releaseName" $releaseName "app" $app "env" .env "envFrom" .envFrom "configmap" $configmap "postgres" $postgres) | nindent 10 -}}
+            {{- include "resources" . | nindent 10 }}
+            {{- include "securitycontext" . | nindent 10 }}
+            {{- if .volumeMounts }}
+            volumeMounts:
+              {{- toYaml .volumeMounts | nindent 12 }}
+            {{- end }}
+          {{- if $postgres.enabled }}
+            {{- include "gcloud_sql_proxy" (dict "postgres" $postgres "app" $app) | indent 8 }}
           {{- end }}
-          {{- if .args }}
-          args: {{ toYaml .args | nindent 10 }}
-          {{- end }}
-          {{- include "environment" (dict "releaseName" $releaseName "app" $app "env" .env "envFrom" .envFrom "configmap" $configmap "postgres" $postgres) | nindent 10 -}}
-          {{- include "resources" . | nindent 10 }}
-          {{- include "securitycontext" . | nindent 10 }}
-          {{- if .volumeMounts }}
-          volumeMounts:
-            {{- toYaml .volumeMounts | nindent 12 }}
-          {{- end }}
-        {{- if $postgres.enabled }}
-          {{- include "gcloud_sql_proxy" (dict "postgres" $postgres "app" $app) | indent 8 }}
         {{- end }}
-      {{- end }}
-      {{- if $cronjob.volumes }}
-      volumes:
-        {{- toYaml $cronjob.volumes | nindent 8 }}
-      {{- end }}
-      {{- if .Values.cron.terminationGracePeriodSeconds }}
-      terminationGracePeriodSeconds: {{ .Values.cron.terminationGracePeriodSeconds }}
-      {{- end }}
-      restartPolicy: Always
-      securityContext:
-        runAsGroup: {{ .Values.container.uid }}
-        runAsNonRoot: true
-        runAsUser: {{ .Values.container.uid }}
+        {{- if $cronjob.volumes }}
+        volumes:
+          {{- toYaml $cronjob.volumes | nindent 8 }}
+        {{- end }}
+        {{- if .Values.cron.terminationGracePeriodSeconds }}
+        terminationGracePeriodSeconds: {{ .Values.cron.terminationGracePeriodSeconds }}
+        {{- end }}
+        restartPolicy: Always
+        securityContext:
+          runAsGroup: {{ .Values.container.uid }}
+          runAsNonRoot: true
+          runAsUser: {{ .Values.container.uid }}
 {{- end -}}

--- a/charts/common/templates/cron.yaml
+++ b/charts/common/templates/cron.yaml
@@ -35,41 +35,42 @@ spec:
         {{- end }}
     spec:
       template:
-        serviceAccountName: application
-        containers:
-        {{ range $containers }}
-          {{- $image := .image | required ".Values.common.container.image is required." -}}
-          {{- printf "\n        " -}}
-          - name: {{ .name | default $app }}
-            image: {{ $image }}
-            imagePullPolicy: Always
-            {{- if .command }}
-            command: {{ .command }}
+        spec:
+          serviceAccountName: application
+          containers:
+          {{ range $containers }}
+            {{- $image := .image | required ".Values.common.container.image is required." -}}
+            {{- printf "\n        " -}}
+            - name: {{ .name | default $app }}
+              image: {{ $image }}
+              imagePullPolicy: Always
+              {{- if .command }}
+              command: {{ .command }}
+              {{- end }}
+              {{- if .args }}
+              args: {{ toYaml .args | nindent 10 }}
+              {{- end }}
+              {{- include "environment" (dict "releaseName" $releaseName "app" $app "env" .env "envFrom" .envFrom "configmap" $configmap "postgres" $postgres) | nindent 10 -}}
+              {{- include "resources" . | nindent 10 }}
+              {{- include "securitycontext" . | nindent 10 }}
+              {{- if .volumeMounts }}
+              volumeMounts:
+                {{- toYaml .volumeMounts | nindent 12 }}
+              {{- end }}
+            {{- if $postgres.enabled }}
+              {{- include "gcloud_sql_proxy" (dict "postgres" $postgres "app" $app) | indent 8 }}
             {{- end }}
-            {{- if .args }}
-            args: {{ toYaml .args | nindent 10 }}
-            {{- end }}
-            {{- include "environment" (dict "releaseName" $releaseName "app" $app "env" .env "envFrom" .envFrom "configmap" $configmap "postgres" $postgres) | nindent 10 -}}
-            {{- include "resources" . | nindent 10 }}
-            {{- include "securitycontext" . | nindent 10 }}
-            {{- if .volumeMounts }}
-            volumeMounts:
-              {{- toYaml .volumeMounts | nindent 12 }}
-            {{- end }}
-          {{- if $postgres.enabled }}
-            {{- include "gcloud_sql_proxy" (dict "postgres" $postgres "app" $app) | indent 8 }}
           {{- end }}
-        {{- end }}
-        {{- if $cronjob.volumes }}
-        volumes:
-          {{- toYaml $cronjob.volumes | nindent 8 }}
-        {{- end }}
-        {{- if .Values.cron.terminationGracePeriodSeconds }}
-        terminationGracePeriodSeconds: {{ .Values.cron.terminationGracePeriodSeconds }}
-        {{- end }}
-        restartPolicy: Always
-        securityContext:
-          runAsGroup: {{ .Values.container.uid }}
-          runAsNonRoot: true
-          runAsUser: {{ .Values.container.uid }}
+          {{- if $cronjob.volumes }}
+          volumes:
+            {{- toYaml $cronjob.volumes | nindent 8 }}
+          {{- end }}
+          {{- if .Values.cron.terminationGracePeriodSeconds }}
+          terminationGracePeriodSeconds: {{ .Values.cron.terminationGracePeriodSeconds }}
+          {{- end }}
+          restartPolicy: Always
+          securityContext:
+            runAsGroup: {{ .Values.container.uid }}
+            runAsNonRoot: true
+            runAsUser: {{ .Values.container.uid }}
 {{- end -}}

--- a/charts/common/templates/cron.yaml
+++ b/charts/common/templates/cron.yaml
@@ -40,7 +40,7 @@ spec:
           containers:
           {{ range $containers }}
             {{- $image := .image | required ".Values.common.container.image is required." -}}
-            {{- printf "\n        " -}}
+            {{- printf "\n            " -}}
             - name: {{ .name | default $app }}
               image: {{ $image }}
               imagePullPolicy: Always
@@ -48,22 +48,22 @@ spec:
               command: {{ .command }}
               {{- end }}
               {{- if .args }}
-              args: {{ toYaml .args | nindent 10 }}
+              args: {{ toYaml .args | nindent 14 }}
               {{- end }}
-              {{- include "environment" (dict "releaseName" $releaseName "app" $app "env" .env "envFrom" .envFrom "configmap" $configmap "postgres" $postgres) | nindent 10 -}}
-              {{- include "resources" . | nindent 10 }}
-              {{- include "securitycontext" . | nindent 10 }}
+              {{- include "environment" (dict "releaseName" $releaseName "app" $app "env" .env "envFrom" .envFrom "configmap" $configmap "postgres" $postgres) | nindent 14 -}}
+              {{- include "resources" . | nindent 14 }}
+              {{- include "securitycontext" . | nindent 14 }}
               {{- if .volumeMounts }}
               volumeMounts:
-                {{- toYaml .volumeMounts | nindent 12 }}
+                {{- toYaml .volumeMounts | nindent 16 }}
               {{- end }}
             {{- if $postgres.enabled }}
-              {{- include "gcloud_sql_proxy" (dict "postgres" $postgres "app" $app) | indent 8 }}
+              {{- include "gcloud_sql_proxy" (dict "postgres" $postgres "app" $app) | indent 12 }}
             {{- end }}
           {{- end }}
           {{- if $cronjob.volumes }}
           volumes:
-            {{- toYaml $cronjob.volumes | nindent 8 }}
+            {{- toYaml $cronjob.volumes | nindent 12 }}
           {{- end }}
           {{- if .Values.cron.terminationGracePeriodSeconds }}
           terminationGracePeriodSeconds: {{ .Values.cron.terminationGracePeriodSeconds }}

--- a/charts/common/tests/cron_test.yaml
+++ b/charts/common/tests/cron_test.yaml
@@ -33,7 +33,7 @@ values: &values
       <<: *probes
 
 
-suite: test deployment
+suite: test cron
 templates:
   - cron.yaml
 tests:
@@ -57,8 +57,8 @@ tests:
     set:
       <<: *values
     asserts:
-      - equal:
-          path: spec.jobTemplate.spec.containers[0].env[0].FOO
+      - equal:      
+          path: spec.jobTemplate.spec.template.spec.containers[0].env[0].FOO
           value: bar
   - it: cpu limit can be overridden
     release:
@@ -72,10 +72,10 @@ tests:
           <<: *probes
     asserts:
       - equal:
-          path: spec.jobTemplate.spec.containers[0].resources.limits.cpu
+          path: spec.jobTemplate.spec.template.spec.containers[0].resources.limits.cpu
           value: 1
       - equal:
-          path: spec.jobTemplate.spec.containers[0].resources.requests.cpu
+          path: spec.jobTemplate.spec.template.spec.containers[0].resources.requests.cpu
           value: 0.1
   - it: cpu limit is 5x request for 0.1
     release:
@@ -88,10 +88,10 @@ tests:
           <<: *probes
     asserts:
       - equal:
-          path: spec.jobTemplate.spec.containers[0].resources.limits.cpu
+          path: spec.jobTemplate.spec.template.spec.containers[0].resources.limits.cpu
           value: 500m
       - equal:
-          path: spec.jobTemplate.spec.containers[0].resources.requests.cpu
+          path: spec.jobTemplate.spec.template.spec.containers[0].resources.requests.cpu
           value: 0.1
   - it: cpu limit is 5x request for 0.75
     release:
@@ -104,10 +104,10 @@ tests:
           <<: *probes
     asserts:
       - equal:
-          path: spec.jobTemplate.spec.containers[0].resources.limits.cpu
+          path: spec.jobTemplate.spec.template.spec.containers[0].resources.limits.cpu
           value: 3750m
       - equal:
-          path: spec.jobTemplate.spec.containers[0].resources.requests.cpu
+          path: spec.jobTemplate.spec.template.spec.containers[0].resources.requests.cpu
           value: 0.75
   - it: cpu limit is 5x request for 1
     release:
@@ -120,10 +120,10 @@ tests:
           <<: *probes
     asserts:
       - equal:
-          path: spec.jobTemplate.spec.containers[0].resources.limits.cpu
+          path: spec.jobTemplate.spec.template.spec.containers[0].resources.limits.cpu
           value: 5000m
       - equal:
-          path: spec.jobTemplate.spec.containers[0].resources.requests.cpu
+          path: spec.jobTemplate.spec.template.spec.containers[0].resources.requests.cpu
           value: 1
   - it: cpu limit is 5x request for > 1
     release:
@@ -136,10 +136,10 @@ tests:
           <<: *probes
     asserts:
       - equal:
-          path: spec.jobTemplate.spec.containers[0].resources.limits.cpu
+          path: spec.jobTemplate.spec.template.spec.containers[0].resources.limits.cpu
           value: 10500m
       - equal:
-          path: spec.jobTemplate.spec.containers[0].resources.requests.cpu
+          path: spec.jobTemplate.spec.template.spec.containers[0].resources.requests.cpu
           value: 2.1
   - it: memory limit is 120 percent of request
     release:
@@ -152,10 +152,10 @@ tests:
           <<: *probes
     asserts:
       - equal:
-          path: spec.jobTemplate.spec.containers[0].resources.limits.memory
+          path: spec.jobTemplate.spec.template.spec.containers[0].resources.limits.memory
           value: 307Mi
       - equal:
-          path: spec.jobTemplate.spec.containers[0].resources.requests.memory
+          path: spec.jobTemplate.spec.template.spec.containers[0].resources.requests.memory
           value: 256Mi
   - it: memory limit can be overridden
     release:
@@ -169,10 +169,10 @@ tests:
           <<: *probes
     asserts:
       - equal:
-          path: spec.jobTemplate.spec.containers[0].resources.limits.memory
+          path: spec.jobTemplate.spec.template.spec.containers[0].resources.limits.memory
           value: 1024Mi
       - equal:
-          path: spec.jobTemplate.spec.containers[0].resources.requests.memory
+          path: spec.jobTemplate.spec.template.spec.containers[0].resources.requests.memory
           value: 256Mi
   - it: terminationGracePeriodSeconds use correct value
     set:
@@ -185,14 +185,14 @@ tests:
         terminationGracePeriodSeconds: 60
     asserts:
       - equal:
-          path: spec.jobTemplate.spec.terminationGracePeriodSeconds
+          path: spec.jobTemplate.spec.template.spec.terminationGracePeriodSeconds
           value: 60
   - it: spec does not contain terminationGracePeriodSeconds if missing from values
     set:
       <<: *values
     asserts:
       - isEmpty:
-          path: spec.jobTemplate.spec.terminationGracePeriodSeconds
+          path: spec.jobTemplate.spec.template.spec.terminationGracePeriodSeconds
   - it: command use correct value
     set:
       <<: *values
@@ -202,14 +202,14 @@ tests:
           command: ["/bin/sh"]
     asserts:
       - equal:
-          path: spec.jobTemplate.spec.containers[0].command
+          path: spec.jobTemplate.spec.template.spec.containers[0].command
           value: ["/bin/sh"]
   - it: spec does not contain command if missing from values
     set:
       <<: *values
     asserts:
       - isEmpty:
-          path: spec.jobTemplate.spec.containers[0].command
+          path: spec.jobTemplate.spec.template.spec.containers[0].command
   - it: args use correct value
     set:
       <<: *values
@@ -219,11 +219,11 @@ tests:
           args: ["-c", "gcloud sql export"]
     asserts:
       - equal:
-          path: spec.jobTemplate.spec.containers[0].args
+          path: spec.jobTemplate.spec.template.spec.containers[0].args
           value: ["-c", "gcloud sql export"]
   - it: spec does not contain args if missing from values
     set:
       <<: *values
     asserts:
       - isEmpty:
-          path: spec.jobTemplate.spec.containers[0].args
+          path: spec.jobTemplate.spec.template.spec.containers[0].args


### PR DESCRIPTION
When trying to use the CronJob resource in the chart, the following error occurs:

```shell
error: error validating "manifests-dry-run.yaml": 
error validating data: [ValidationError(CronJob.spec.jobTemplate.spec): 
unknown field "containers" in io.k8s.api.batch.v1.JobSpec, ValidationError(CronJob.spec.jobTemplate.spec): 
unknown field "restartPolicy" in io.k8s.api.batch.v1.JobSpec, ValidationError(CronJob.spec.jobTemplate.spec): 
unknown field "securityContext" in io.k8s.api.batch.v1.JobSpec, ValidationError(CronJob.spec.jobTemplate.spec): 
unknown field "serviceAccountName" in io.k8s.api.batch.v1.JobSpec, 
ValidationError(CronJob.spec.jobTemplate.spec): missing required field "template" in io.k8s.api.batch.v1.JobSpec]; 
if you choose to ignore these errors, turn validation off with --validate=false
```

According to [the docs](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#example), the structure should be as follows:

```yaml
spec:
  jobTemplate:
    spec:
      template:
        spec:
          containers:
```