### PR TITLE
feat: Add support for setting maxUnavailable and maxSurge for rolling updates

### DIFF
--- a/charts/common/README.md
+++ b/charts/common/README.md
@@ -66,6 +66,8 @@ Highlighted features:
 | deployment.enabled | bool | `true` | Enable or disable the deployment |
 | deployment.forceReplicas | int | `nil` | Force replicas disables autoscaling, if set to 1 it will use Recreate strategy |
 | deployment.labels | object | `{}` | Add labels to your pods |
+| deployment.maxSurge | string | `nil` | Limit max surge for rolling updates (default 25%). Not in use when using forceReplicas. |
+| deployment.maxUnavailable | string | `nil` | Limit max unavailable for rolling updates (default 25%). Not in use when using forceReplicas. |
 | deployment.replicas | string | container.replicas | Set the target replica count |
 | deployment.terminationGracePeriodSeconds | int | `nil` | Override pod terminationGracePeriodSeconds (default 30s). |
 | deployment.volumes | list | `[]` | Configure volume, accepts kubernetes syntax |

--- a/charts/common/templates/deployment.yaml
+++ b/charts/common/templates/deployment.yaml
@@ -17,6 +17,8 @@
 {{- $replicas := .Values.deployment.replicas | default .Values.container.replicas }}
 {{- $forceReplicas := .Values.deployment.forceReplicas | default .Values.container.forceReplicas }}
 {{- $terminationGracePeriodSeconds := .Values.deployment.terminationGracePeriodSeconds | default .Values.container.terminationGracePeriodSeconds }}
+{{- $maxSurge := .Values.deployment.maxSurge | default "25%" }}
+{{- $maxUnavailable := .Values.deployment.maxUnavailable | default "25%" }}
 {{- if $enabled }}
 {{- /* YAML Spec */}}
 apiVersion: apps/v1
@@ -40,6 +42,9 @@ spec:
     type: Recreate
     {{- else }}
     type: RollingUpdate
+    rollingUpdate:
+      maxSurge: {{ $maxSurge }}
+      maxUnavailable: {{ $maxUnavailable }}
     {{- end }}
   template:
     metadata:

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -45,6 +45,10 @@ deployment:
   forceReplicas:
   # -- (int) Override pod terminationGracePeriodSeconds (default 30s).
   terminationGracePeriodSeconds:
+  # -- Limit max surge for rolling updates (default 25%). Not in use when using forceReplicas.
+  maxSurge:
+  # -- Limit max unavailable for rolling updates (default 25%). Not in use when using forceReplicas.
+  maxUnavailable:
 
 cron:
   # -- Enable or disable the cron job


### PR DESCRIPTION
Allowing team tilbud to set maxSurge: 0% to avoid increasing load on existing pods during deployment.