### PR TITLE
feat: Make serviceAccountName overridable for Deployment and CronJob resources

### DIFF
--- a/charts/common/README.md
+++ b/charts/common/README.md
@@ -58,7 +58,9 @@ Highlighted features:
 | cron.enabled | bool | `false` | Enable or disable the cron job |
 | cron.failedJobsHistoryLimit | int | 1 | Failed jobs history limit |
 | cron.labels | object | `{}` | Add labels to your pods |
+| cron.restartPolicy | string | OnFailure | Override pod restartPolicy (default OnFailure). |
 | cron.schedule | string | `nil` | Required crontab schedule `* * * * * *` |
+| cron.serviceAccountName | string | application | Override pod serviceAccountName (default application). |
 | cron.successfulJobsHistoryLimit | int | 1 | Successful jobs history limit |
 | cron.suspend | string | false | Suspend flag |
 | cron.terminationGracePeriodSeconds | int | false | Override pod terminationGracePeriodSeconds (default 30s). |
@@ -69,6 +71,7 @@ Highlighted features:
 | deployment.maxSurge | string | `nil` | Limit max surge for rolling updates (default 25%). Not in use when using forceReplicas. |
 | deployment.maxUnavailable | string | `nil` | Limit max unavailable for rolling updates (default 25%). Not in use when using forceReplicas. |
 | deployment.replicas | string | container.replicas | Set the target replica count |
+| deployment.serviceAccountName | string | application | Override pod serviceAccountName (default application). |
 | deployment.terminationGracePeriodSeconds | int | `nil` | Override pod terminationGracePeriodSeconds (default 30s). |
 | deployment.volumes | list | `[]` | Configure volume, accepts kubernetes syntax |
 | deployments | list | `[]` | Specify a list of `deployment` specs |

--- a/charts/common/templates/cron.yaml
+++ b/charts/common/templates/cron.yaml
@@ -72,7 +72,7 @@ spec:
           {{- if .Values.cron.terminationGracePeriodSeconds }}
           terminationGracePeriodSeconds: {{ .Values.cron.terminationGracePeriodSeconds }}
           {{- end }}
-          restartPolicy: Always
+          restartPolicy: {{ .Values.cron.restartPolicy | required ".Values.common.cron.restartPolicy is required." }}
           securityContext:
             runAsGroup: {{ .Values.container.uid }}
             runAsNonRoot: true

--- a/charts/common/templates/cron.yaml
+++ b/charts/common/templates/cron.yaml
@@ -72,7 +72,7 @@ spec:
           {{- if .Values.cron.terminationGracePeriodSeconds }}
           terminationGracePeriodSeconds: {{ .Values.cron.terminationGracePeriodSeconds }}
           {{- end }}
-          restartPolicy: {{ .Values.cron.restartPolicy | required ".Values.common.cron.restartPolicy is required." }}
+          restartPolicy: {{ .Values.cron.restartPolicy | default "OnFailure" }}
           securityContext:
             runAsGroup: {{ .Values.container.uid }}
             runAsNonRoot: true

--- a/charts/common/templates/cron.yaml
+++ b/charts/common/templates/cron.yaml
@@ -36,7 +36,7 @@ spec:
     spec:
       template:
         spec:
-          serviceAccountName: application
+          serviceAccountName: {{ .Values.cron.serviceAccountName | default "application" }}
           containers:
           {{ range $containers }}
             {{- $image := .image | required ".Values.common.container.image is required." -}}

--- a/charts/common/templates/deployment.yaml
+++ b/charts/common/templates/deployment.yaml
@@ -61,7 +61,7 @@ spec:
         {{- toYaml $labels | nindent 8 }}
         {{- end }}
     spec:
-      serviceAccountName: application
+      serviceAccountName: {{ .Values.deployment.serviceAccountName | default "application" }}
 
       containers:
       {{ range $containers }}

--- a/charts/common/tests/cron_test.yaml
+++ b/charts/common/tests/cron_test.yaml
@@ -233,8 +233,6 @@ tests:
       cron:
         enabled: true
         schedule: "30 04 * ? *"
-        labels:
-          version: 1        
     asserts:
       - equal:
           path: spec.jobTemplate.spec.template.spec.restartPolicy
@@ -244,7 +242,7 @@ tests:
       <<: *values
       cron:
         enabled: true
-        schedule: "30 04 * ? *"    
+        schedule: "30 04 * ? *"
         restartPolicy: Never
     asserts:
       - equal:
@@ -255,7 +253,7 @@ tests:
       <<: *values
       cron:
         enabled: true
-        schedule: "30 04 * ? *"      
+        schedule: "30 04 * ? *"
     asserts:
       - equal:
           path: spec.jobTemplate.spec.template.spec.serviceAccountName
@@ -265,7 +263,7 @@ tests:
       <<: *values
       cron:
         enabled: true
-        schedule: "30 04 * ? *"        
+        schedule: "30 04 * ? *"
         serviceAccountName: myaccount
     asserts:
       - equal:

--- a/charts/common/tests/cron_test.yaml
+++ b/charts/common/tests/cron_test.yaml
@@ -227,3 +227,28 @@ tests:
     asserts:
       - isEmpty:
           path: spec.jobTemplate.spec.template.spec.containers[0].args
+  - it: restartPolicy use correct default value
+    set:
+      <<: *values
+      cron:
+        enabled: true
+        schedule: "30 04 * ? *"
+        labels:
+          version: 1        
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.restartPolicy
+          value: OnFailure
+  - it: restartPolicy use correct value when overridden
+    set:
+      <<: *values
+      cron:
+        enabled: true
+        schedule: "30 04 * ? *"
+        labels:
+          version: 1
+        restartPolicy: Never
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.restartPolicy
+          value: Never

--- a/charts/common/tests/cron_test.yaml
+++ b/charts/common/tests/cron_test.yaml
@@ -244,11 +244,30 @@ tests:
       <<: *values
       cron:
         enabled: true
-        schedule: "30 04 * ? *"
-        labels:
-          version: 1
+        schedule: "30 04 * ? *"    
         restartPolicy: Never
     asserts:
       - equal:
           path: spec.jobTemplate.spec.template.spec.restartPolicy
           value: Never
+  - it: serviceAccountName use correct default value
+    set:
+      <<: *values
+      cron:
+        enabled: true
+        schedule: "30 04 * ? *"      
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.serviceAccountName
+          value: application
+  - it: serviceAccountName use correct value when overridden
+    set:
+      <<: *values
+      cron:
+        enabled: true
+        schedule: "30 04 * ? *"        
+        serviceAccountName: myaccount
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.serviceAccountName
+          value: myaccount

--- a/charts/common/tests/deployment_test.yaml
+++ b/charts/common/tests/deployment_test.yaml
@@ -362,3 +362,19 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[0]
           value: echo
+  - it: serviceAccountName use correct default value
+    set:
+      <<: *values
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: application
+  - it: serviceAccountName use correct value when overridden
+    set:
+      <<: *values
+      deployment:
+        serviceAccountName: myaccount
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: myaccount

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -49,7 +49,7 @@ deployment:
   maxSurge:
   # -- Limit max unavailable for rolling updates (default 25%). Not in use when using forceReplicas.
   maxUnavailable:
-  # -- (int) Override pod serviceAccountName (default application).
+  # -- Override pod serviceAccountName (default application).
   # @default -- application
   serviceAccountName:
 

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -49,6 +49,9 @@ deployment:
   maxSurge:
   # -- Limit max unavailable for rolling updates (default 25%). Not in use when using forceReplicas.
   maxUnavailable:
+  # -- (int) Override pod serviceAccountName (default application).
+  # @default -- application
+  serviceAccountName:
 
 cron:
   # -- Enable or disable the cron job
@@ -74,6 +77,12 @@ cron:
   # -- (int) Override pod terminationGracePeriodSeconds (default 30s).
   # @default -- false
   terminationGracePeriodSeconds:
+  # -- Override pod restartPolicy (default OnFailure).
+  # @default -- OnFailure
+  restartPolicy:
+  # -- Override pod serviceAccountName (default application).
+  # @default -- application
+  serviceAccountName:
 
 hpa:
   # -- Custom spec for HPA, inherits `scaleTargetRef` and min/max replicas.


### PR DESCRIPTION
This pull request contains two changes:

* It fixes #69 
* It fixes an issue with the CronJob resource where the default value `Always` is [not a permitted value](https://kubernetes.io/docs/concepts/workloads/controllers/job/#pod-template) for the `RestartPolicy` field