### PR TITLE
feat: enable releaseName override

### DIFF
--- a/charts/common/README.md
+++ b/charts/common/README.md
@@ -88,6 +88,7 @@ Highlighted features:
 | postgres.cpuLimit | float | `nil` | Configure cpu limit for proxy |
 | postgres.enabled | bool | false | Enable or disable the proxy |
 | postgres.memory | int | 16 | Configure memory request for proxy without units, `Mi` inferred |
+| releaseName | string | `nil` | Override release name, useful for multiple deployments |
 | service.enabled | bool | `true` | Enable or disable the service |
 | service.externalPort | int | 80 | Set the external port for your service |
 | service.internalPort | int | 8080 | Set the internal port for your service |

--- a/charts/common/templates/_helpers.tpl
+++ b/charts/common/templates/_helpers.tpl
@@ -1,5 +1,9 @@
+{{- define "name" -}}
+{{ empty .Values.releaseName | ternary .Release.Name .Values.releaseName }}
+{{- end -}}
+
 {{- define "labels" }}
-app: {{ .Release.Name }}
+app: {{ empty .Values.releaseName | ternary .Release.Name .Values.releaseName }}
 shortname: {{ .Values.shortname }}
 team: {{ .Values.team }}
 common: {{ .Chart.Version }}

--- a/charts/common/templates/_helpers.tpl
+++ b/charts/common/templates/_helpers.tpl
@@ -30,13 +30,13 @@ topologySpreadConstraints:
     whenUnsatisfiable: ScheduleAnyway
     labelSelector:
       matchLabels:
-        app: {{ .Release.Name }}
+        app: {{ empty .Values.releaseName | ternary .Release.Name .Values.releaseName }}
   - maxSkew: 5
     topologyKey: "topology.kubernetes.io/zone"
     whenUnsatisfiable: ScheduleAnyway
     labelSelector:
       matchLabels:
-        app: {{ .Release.Name }}
+        app: {{ empty .Values.releaseName | ternary .Release.Name .Values.releaseName }}
 {{- end }}
 
 {{- define "resources" }}

--- a/charts/common/templates/configmap.yaml
+++ b/charts/common/templates/configmap.yaml
@@ -1,13 +1,14 @@
 {{- if .Values.configmap.enabled }}
   {{- /* Rules */}}
   {{- $data := .Values.configmap.data | required ".Values.common.configmap.data is required." -}}
+  {{- $releaseName := include "name" . -}}
 {{- /* YAML Spec */}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
     {{- include "labels" . | indent 4 }}
-  name: {{ .Release.Name }}
+  name: {{ $releaseName }}
   namespace: {{ .Release.Namespace }}
 data:
   {{- toYaml $data | nindent 2 }}

--- a/charts/common/templates/cron.yaml
+++ b/charts/common/templates/cron.yaml
@@ -4,7 +4,7 @@
 {{- $shortname := .Values.shortname | required ".Values.common.shortname is required." -}}
 {{- $team := .Values.team | required ".Values.common.team is required." -}}
 
-{{- $releaseName := .Release.Name -}}
+{{- $releaseName := include "name" . -}}
 {{- $containers := .Values.containers | default (list .Values.container) -}}
 {{- $configmap := .Values.configmap -}}
 {{- $postgres := .Values.postgres -}}
@@ -16,7 +16,7 @@ kind: CronJob
 metadata:
   labels:
     {{- include "labels" . | indent 4 }}
-  name: {{ .Release.Name }}
+  name: {{ $releaseName }}
   namespace: {{ .Release.Namespace }}
 spec:
   concurrencyPolicy: {{ $cronjob.concurrencyPolicy | default "Forbid" }}

--- a/charts/common/templates/deployment.yaml
+++ b/charts/common/templates/deployment.yaml
@@ -4,7 +4,7 @@
 {{- $shortname := .Values.shortname | required ".Values.common.shortname is required." -}}
 {{- $team := .Values.team | required ".Values.common.team is required." -}}
 
-{{- $releaseName := .Release.Name -}}
+{{- $releaseName := include "name" . -}}
 {{- $containers := .Values.containers | default (list .Values.container) -}}
 {{- $configmap := .Values.configmap -}}
 {{- $postgres := .Values.postgres -}}
@@ -26,12 +26,12 @@ kind: Deployment
 metadata:
   labels:
     {{- include "labels" . | indent 4 }}
-  name: {{ .Release.Name }}
+  name: {{ $releaseName }}
   namespace: {{ .Release.Namespace }}
 spec:
   selector:
     matchLabels:
-      app: {{ .Release.Name }}
+      app: {{ $releaseName }}
   {{- if $forceReplicas }}
   replicas: {{ $forceReplicas }}
   {{- else }}

--- a/charts/common/templates/hpa.yaml
+++ b/charts/common/templates/hpa.yaml
@@ -1,5 +1,6 @@
 {{- /* Rules */}}
 {{- $env := .Values.env | required ".Values.common.env is required." -}}
+{{- $releaseName := include "name" . -}}
 
 {{- if (and (not .Values.container.forceReplicas) (or (eq "prd" .Values.env) .Values.container.maxReplicas)) }}
   {{- /* Defaults */}}
@@ -15,7 +16,7 @@
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ .Release.Name }}
+  name: {{ $releaseName }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "labels" . | indent 4 }}
@@ -36,6 +37,6 @@ spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ .Release.Name }}
+    name: {{ $releaseName }}
 {{- end }}
 {{- end }}

--- a/charts/common/templates/ingress.yaml
+++ b/charts/common/templates/ingress.yaml
@@ -2,7 +2,7 @@
   {{- /* Rules */}}
   {{- $externalPort :=  .Values.service.externalPort  -}}
   {{- $chart := . -}}
-  {{- $releaseName := .Release.Name -}}
+  {{- $releaseName := include "name" . -}}
   {{- $releaseNamespace := .Release.Namespace -}}
   {{- $ingresses := .Values.ingresses | default (list .Values.ingress) -}}
 

--- a/charts/common/templates/pdb.yaml
+++ b/charts/common/templates/pdb.yaml
@@ -1,5 +1,6 @@
 {{- /* Rules */}}
 {{- $env := .Values.env | required ".Values.common.env is required." -}}
+{{- $releaseName := include "name" . -}}
 
 {{- if (and (not (eq (int .Values.container.forceReplicas) 1)) (or (eq "prd" .Values.env) .Values.container.minAvailable) )}}
   {{- if (and (ne "prd" .Values.env) (eq 1 (int .Values.container.replicas))) }}
@@ -10,7 +11,7 @@
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
-  name: {{ .Release.Name }}
+  name: {{ $releaseName }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "labels" . | indent 4 }}
@@ -24,5 +25,5 @@ spec:
   {{- end }}
   selector:
     matchLabels:
-      app: {{ .Release.Name }}
+      app: {{ $releaseName }}
 {{- end }}

--- a/charts/common/templates/service.yaml
+++ b/charts/common/templates/service.yaml
@@ -1,10 +1,11 @@
+{{- $releaseName := include "name" . -}}
 {{- if .Values.service.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
   labels:
     {{- include "labels" . | indent 4 }}
-  name: {{ .Release.Name }}
+  name: {{ $releaseName }}
   {{- if .Values.grpc }}
   annotations:
     traefik.ingress.kubernetes.io/service.serversscheme: h2c
@@ -21,6 +22,6 @@ spec:
     targetPort: {{ .Values.service.internalPort }}
   {{- end }}
   selector:
-    app: {{ .Release.Name }}
+    app: {{ $releaseName }}
   type: ClusterIP
 {{- end }}

--- a/charts/common/tests/configmap_test.yaml
+++ b/charts/common/tests/configmap_test.yaml
@@ -27,3 +27,11 @@ tests:
       - equal:
           path: data.FOO
           value: bar
+  - it: can override release name
+    set:
+      <<: *values
+      releaseName: override
+    asserts:
+      - equal:
+          path: metadata.name
+          value: override

--- a/charts/common/tests/cron_test.yaml
+++ b/charts/common/tests/cron_test.yaml
@@ -269,3 +269,11 @@ tests:
       - equal:
           path: spec.jobTemplate.spec.template.spec.serviceAccountName
           value: myaccount
+  - it: can override release name
+    set:
+      <<: *values
+      releaseName: override
+    asserts:
+      - equal:
+          path: metadata.name
+          value: override

--- a/charts/common/tests/deployment_test.yaml
+++ b/charts/common/tests/deployment_test.yaml
@@ -378,3 +378,11 @@ tests:
       - equal:
           path: spec.template.spec.serviceAccountName
           value: myaccount
+  - it: can override release name
+    set:
+      <<: *values
+      releaseName: override
+    asserts:
+      - equal:
+          path: metadata.name
+          value: override

--- a/charts/common/tests/hpa_test.yaml
+++ b/charts/common/tests/hpa_test.yaml
@@ -84,3 +84,12 @@ tests:
       - equal:
           path: spec.metrics[0].resource.target.averageUtilization
           value: 200
+  - it: can override release name
+    set:
+      <<: *values
+      env: prd
+      releaseName: override
+    asserts:
+      - equal:
+          path: metadata.name
+          value: override

--- a/charts/common/tests/ingress_test.yaml
+++ b/charts/common/tests/ingress_test.yaml
@@ -139,3 +139,11 @@ tests:
           path: spec.rules[0].host
           value: bad.io
         documentIndex: 1
+  - it: can override release name
+    set:
+      <<: *values
+      releaseName: override
+    asserts:
+      - equal:
+          path: metadata.name
+          value: override

--- a/charts/common/tests/pdb_test.yaml
+++ b/charts/common/tests/pdb_test.yaml
@@ -52,3 +52,12 @@ tests:
     asserts:
       - hasDocuments:
           count: 1
+  - it: can override release name
+    set:
+      <<: *values
+      env: prd
+      releaseName: override
+    asserts:
+      - equal:
+          path: metadata.name
+          value: override

--- a/charts/common/tests/service_test.yaml
+++ b/charts/common/tests/service_test.yaml
@@ -47,3 +47,11 @@ tests:
       - isNotEmpty:
           template: service.yaml
           path: metadata.annotations
+  - it: can override release name
+    set:
+      <<: *values
+      releaseName: override
+    asserts:
+      - equal:
+          path: metadata.name
+          value: override

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -6,6 +6,8 @@ shortname:
 team:
 # -- The current env, override in your `values-kub-ent-$env.yaml` files to `dev`, `tst` or `prd`
 env:
+# -- Override release name, useful for multiple deployments
+releaseName:
 
 # -- Specify additional labels for every resource
 # @default -- `{ app shortname team common:version environment }`


### PR DESCRIPTION
Enable override of `.Release.Name` with

```yaml
common:
  releaseName: my-name
```

Useful for multi-deployment configurations.