### PR TITLE
fix: add annotations to service, needed for internal-http2

### DIFF
--- a/charts/common/README.md
+++ b/charts/common/README.md
@@ -92,6 +92,7 @@ Highlighted features:
 | postgres.enabled | bool | false | Enable or disable the proxy |
 | postgres.memory | int | 16 | Configure memory request for proxy without units, `Mi` inferred |
 | releaseName | string | `nil` | Override release name, useful for multiple deployments |
+| service.annotations | object | `{}` | Optionally set annotations for the service |
 | service.enabled | bool | `true` | Enable or disable the service |
 | service.externalPort | int | 80 | Set the external port for your service |
 | service.internalPort | int | 8080 | Set the internal port for your service |

--- a/charts/common/templates/service.yaml
+++ b/charts/common/templates/service.yaml
@@ -6,9 +6,12 @@ metadata:
   labels:
     {{- include "labels" . | indent 4 }}
   name: {{ $releaseName }}
-  {{- if .Values.grpc }}
   annotations:
+  {{- if .Values.grpc }}
     traefik.ingress.kubernetes.io/service.serversscheme: h2c
+  {{- end }}
+  {{- if .Values.service.annotations }}
+    {{- toYaml .Values.service.annotations | nindent 4 }}
   {{- end }}
   namespace: {{ .Release.Namespace }}
 spec:

--- a/charts/common/tests/service_test.yaml
+++ b/charts/common/tests/service_test.yaml
@@ -39,6 +39,13 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
+  - it: emtpy annotations has no annotations
+    set:
+      <<: *values
+    asserts:
+      - isEmpty:
+          template: service.yaml
+          path: metadata.annotations
   - it: adds metadata for gRPC
     set:
       <<: *values
@@ -46,7 +53,17 @@ tests:
     asserts:
       - isNotEmpty:
           template: service.yaml
-          path: metadata.annotations
+          path: metadata.annotations.traefik\.ingress\.kubernetes\.io/service\.serversscheme
+  - it: can be internal grpc
+    set:
+      <<: *values
+      service:
+        annotations: 
+          entur.no/internal-http2: "true"
+    asserts:
+      - isNotEmpty:
+          template: service.yaml
+          path: metadata.annotations.entur\.no/internal-http2
   - it: can override release name
     set:
       <<: *values

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -106,6 +106,8 @@ service:
   # -- Set the internal port for your service
   # @default -- 8080
   internalPort: 8080
+  # -- Optionally set annotations for the service
+  annotations: {}
 
 # -- Takes a list of `container` entries, you must add a `name` field for each entry
 containers: []


### PR DESCRIPTION
Add support for 

```yaml
common:
  service:
    annotations: 
      entur.no/internal-http2: "true"
```