### PR TITLE
fix: labels follows terraform convention

### DIFF
--- a/charts/common/templates/_helpers.tpl
+++ b/charts/common/templates/_helpers.tpl
@@ -4,8 +4,8 @@
 
 {{- define "labels" }}
 app: {{ empty .Values.releaseName | ternary .Release.Name .Values.releaseName }}
-shortname: {{ .Values.shortname }}
-team: {{ .Values.team }}
+app_id: {{ .Values.shortname }}
+team: team-{{ .Values.team }}
 common: {{ .Chart.Version }}
 environment: {{ .Values.env }}
 {{- if .Values.labels }}

--- a/charts/common/tests/deployment_v1_test.yaml
+++ b/charts/common/tests/deployment_v1_test.yaml
@@ -25,16 +25,23 @@ tests:
     asserts:
       - isNotEmpty:
           template: deployment.yaml
-          path: metadata.labels
-      - isNotEmpty:
-          template: deployment.yaml
-          path: metadata.labels.environment
-      - isNotEmpty:
-          template: deployment.yaml
           path: metadata.labels.custom
       - isNotEmpty:
           template: deployment.yaml
           path: spec.template.metadata.labels.common
+      - equal:
+          path: metadata.labels.app
+          value: RELEASE-NAME
+      - equal:
+          path: metadata.labels.app_id
+          value: tstsut
+      - equal:
+          path: metadata.labels.environment
+          value: dev
+      - equal:
+          path: metadata.labels.team
+          value: team-common
+
   - it: must add to env if listed
     set:
       <<: *values


### PR DESCRIPTION
https://github.com/entur/terraform-google-init/blob/8b8051e07af0174d15108f763004bf58516c2868/modules/init/outputs.tf#L6-L15

```terraform
output "labels" {
  description = "Labels for use on managed resources (i.e. Kubernetes resources)."
  value = {
    app         = local.app.name
    app_id      = var.app_id
    environment = var.environment
    owner       = local.app.owner
    team        = local.app.owner
  }
}
```