### PR TITLE
feat: option to add custom annotations for ingress

### DIFF
--- a/charts/common/README.md
+++ b/charts/common/README.md
@@ -82,6 +82,7 @@ Highlighted features:
 | env | string | `nil` | The current env, override in your `values-kub-ent-$env.yaml` files to `dev`, `tst` or `prd` |
 | grpc | bool | `false` | Enable gRPC which will add an annotation and use grpc probes |
 | hpa.spec | object | `{}` | Custom spec for HPA, inherits `scaleTargetRef` and min/max replicas. |
+| ingress.annotations | object | `{}` | Optionally set annotations for the ingress |
 | ingress.enabled | bool | `true` | Enable or disable the ingress |
 | ingress.host | string | `nil` | Set the host name, do this in your `values-kub-ent-$env.yaml` files |
 | ingress.trafficType | string | `nil` | Set the traffic type, typically `api` or `public` |

--- a/charts/common/templates/ingress.yaml
+++ b/charts/common/templates/ingress.yaml
@@ -14,6 +14,9 @@ kind: Ingress
 metadata:
   annotations:
     kubernetes.io/ingress.class: traefik
+  {{- if .annotations }}
+    {{- toYaml .annotations | nindent 4 }}
+  {{- end }}
   labels:
     traffic-type: {{ .trafficType }}
     {{- include "labels" $chart | indent 4 }}

--- a/charts/common/tests/ingress_test.yaml
+++ b/charts/common/tests/ingress_test.yaml
@@ -147,3 +147,15 @@ tests:
       - equal:
           path: metadata.name
           value: override
+  - it: can add custom ingress-annotations
+    set:
+      <<: *values
+      ingress:
+        host: test.dev.entur.io
+        trafficType: public
+        annotations:
+          ingress.kubernetes.io/protocol: h2c
+    asserts:
+      - isNotEmpty:
+          template: ingress.yaml
+          path: metadata.annotations.ingress\.kubernetes\.io/protocol

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -20,7 +20,10 @@ ingress:
   host:
   # -- Set the traffic type, typically `api` or `public`
   trafficType:
+  # -- Optionally set annotations for the service
+  annotations: {}
   # rules: # k8s spec for ingress rules
+
 
 # -- Specify a list of `ingress` specs
 ingresses: []

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -20,7 +20,7 @@ ingress:
   host:
   # -- Set the traffic type, typically `api` or `public`
   trafficType:
-  # -- Optionally set annotations for the service
+  # -- Optionally set annotations for the ingress
   annotations: {}
   # rules: # k8s spec for ingress rules
 


### PR DESCRIPTION
Support adding custom annotations for `Ingress`. 

```
      ingress:
        ...
        annotations:
          ingress.kubernetes.io/protocol: h2c
```