### PR TITLE
fix: For PDB-validation, use replicas from deployment if set.

### DIFF
--- a/charts/common/templates/pdb.yaml
+++ b/charts/common/templates/pdb.yaml
@@ -3,9 +3,10 @@
 {{- $releaseName := include "name" . -}}
 {{- $minAvailable := .Values.deployment.minAvailable | default .Values.container.minAvailable }}
 {{- $forceReplicas := .Values.deployment.forceReplicas | default .Values.container.forceReplicas }}
+{{- $replicas := .Values.deployment.replicas | default .Values.container.replicas }}
 
 {{- if (and (not (eq (int $forceReplicas) 1)) (or (eq "prd" .Values.env) $minAvailable) )}}
-  {{- if (and (ne "prd" .Values.env) (eq 1 (int .Values.container.replicas))) }}
+  {{- if (and (ne "prd" .Values.env) (eq 1 (int $replicas))) }}
     {{ $checkReplicas := .Values.error | required ".Values.common.container.replicas must be greater than 1 when using minAvailable" }}
   {{- end }}
 

--- a/charts/common/tests/pdb_test.yaml
+++ b/charts/common/tests/pdb_test.yaml
@@ -55,6 +55,21 @@ tests:
       - equal:
           path: spec.minAvailable
           value: "25%"
+  - it: check for replicas on deployment before container
+    set:
+      <<: *values
+      env: tst
+      deployment:
+        minAvailable: 25%
+        replicas: 2
+      container:
+        replicas: 1
+      containers:
+        - image: app
+    asserts:
+      - equal:
+          path: spec.minAvailable
+          value: "25%"
   - it: use minAvailable from pdb if not set on pdb or container
     set:
       <<: *values


### PR DESCRIPTION
Had an issue for one of the abt-apps for this one.