### PR TITLE
fix: close #101 and fallback to internalPort for grpc probes

### DIFF
--- a/charts/common/README.md
+++ b/charts/common/README.md
@@ -34,6 +34,7 @@ Highlighted features:
 | container.minAvailable | string | 50% | Set the minimal available replicas, used by PDB |
 | container.name | string | .app | Name of container |
 | container.probes.enabled | bool | `true` | Enable or disable probes |
+| container.probes.grpc | bool | `false` | If this is true, use default grpc with internalPort |
 | container.probes.liveness.failureThreshold | int | 6 | Set the failure threshold |
 | container.probes.liveness.grpc | string | `nil` | Specify grpc probes for a port. Needs `port` child stanza |
 | container.probes.liveness.initialDelaySeconds | int | `0` | Set the initial delay for the probe |

--- a/charts/common/templates/_helpers.tpl
+++ b/charts/common/templates/_helpers.tpl
@@ -109,7 +109,7 @@ startupProbe:
 {{- define "grpcprobes" }}
 startupProbe:
   grpc:
-    {{ if (kindIs "bool" .probes.startup.grpc) }}
+    {{ if .probes.grpc }}
     port: {{ .internalPort }}
     {{- else }}
     port: {{ .probes.startup.grpc.port }}
@@ -119,7 +119,7 @@ startupProbe:
   periodSeconds: 10
 readinessProbe:
   grpc:
-    {{ if (kindIs "bool" .probes.readiness.grpc) }}
+    {{ if .probes.grpc }}
     port: {{ .internalPort }}
     {{- else }}
     port: {{ .probes.readiness.grpc.port }}
@@ -129,7 +129,7 @@ readinessProbe:
   timeoutSeconds: 5
 livenessProbe:
   grpc:
-    {{ if (kindIs "bool" .probes.liveness.grpc) }}
+    {{ if .probes.grpc }}
     port: {{ .internalPort }}
     {{- else }}
     port: {{ .probes.liveness.grpc.port }}

--- a/charts/common/templates/_helpers.tpl
+++ b/charts/common/templates/_helpers.tpl
@@ -109,19 +109,31 @@ startupProbe:
 {{- define "grpcprobes" }}
 startupProbe:
   grpc:
-    port: {{ .probes.startup.grpc.port | default .internalPort }}
+    {{ if (kindIs "bool" .probes.startup.grpc) }}
+    port: {{ .internalPort }}
+    {{- else }}
+    port: {{ .probes.startup.grpc.port }}
+    {{- end }}
   initialDelaySeconds: 10
   failureThreshold: 30
   periodSeconds: 10
 readinessProbe:
   grpc:
-    port: {{ .probes.readiness.grpc.port | default .internalPort }}
+    {{ if (kindIs "bool" .probes.readiness.grpc) }}
+    port: {{ .internalPort }}
+    {{- else }}
+    port: {{ .probes.readiness.grpc.port }}
+    {{- end }}
   initialDelaySeconds: 10
   periodSeconds: 10
   timeoutSeconds: 5
 livenessProbe:
   grpc:
-    port: {{ .probes.liveness.grpc.port | default .internalPort }}
+    {{ if (kindIs "bool" .probes.liveness.grpc) }}
+    port: {{ .internalPort }}
+    {{- else }}
+    port: {{ .probes.liveness.grpc.port }}
+    {{- end }}
   initialDelaySeconds: 10
   periodSeconds: 10
   timeoutSeconds: 5

--- a/charts/common/templates/deployment.yaml
+++ b/charts/common/templates/deployment.yaml
@@ -87,7 +87,7 @@ spec:
           {{- include "resources" . | nindent 10 }}
           {{- include "securitycontext" . | nindent 10 }}
           {{- if or $grpc .grpc }}
-            {{- if .probes.liveness.grpc }}
+            {{- if or .probes.grpc .probes.liveness.grpc }}
               {{- include "grpcprobes" (dict "internalPort" $internalPort "probes" .probes) | nindent 10 -}}
             {{- else }}
               {{- include "grpcexecprobes" (dict "internalPort" $internalPort) | nindent 10 -}}

--- a/charts/common/tests/deployment_test.yaml
+++ b/charts/common/tests/deployment_test.yaml
@@ -13,6 +13,9 @@ values: &values
   app: testsuite
   shortname: tstsut
   team: common
+  service:
+    externalPort: 8080
+    internalPort: 8080
   ingress:
     host: test.dev.entur.io
     trafficType: public
@@ -270,6 +273,30 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].startupProbe.grpc.port
           value: 8154
+  - it: must adopt for new gRPC probes 1.24 use internalPort fallback
+    set:
+      <<: *values
+      containers:
+        - name: test
+          image: img
+          grpc: true
+          probes:
+            liveness:
+              grpc: true
+            readiness:
+              grpc: true
+            startup:
+              grpc: true
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.grpc.port
+          value: 8080
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.grpc.port
+          value: 8080
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.grpc.port
+          value: 8080
   - it: must be able to override initialDelay and successThreshold for probes
     set:
       <<: *values

--- a/charts/common/tests/deployment_test.yaml
+++ b/charts/common/tests/deployment_test.yaml
@@ -281,12 +281,7 @@ tests:
           image: img
           grpc: true
           probes:
-            liveness:
-              grpc: true
-            readiness:
-              grpc: true
-            startup:
-              grpc: true
+            grpc: true
     asserts:
       - equal:
           path: spec.template.spec.containers[0].livenessProbe.grpc.port

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -180,6 +180,8 @@ container:
   probes:
     # -- Enable or disable probes
     enabled: true
+    # -- If this is true, use default grpc with internalPort
+    grpc: false
     # -- Override with k8s spec for custom probes
     spec:
       # livenessProbe:


### PR DESCRIPTION
Specifying `true` will use `internalPort`.
```yaml
          probes:
            grpc: true
```