### PR TITLE
feat: Make path overridable for startup probe and add timeoutSeconds property to all probe types

### DIFF
--- a/charts/common/README.md
+++ b/charts/common/README.md
@@ -39,17 +39,24 @@ Highlighted features:
 | container.probes.liveness.initialDelaySeconds | int | `0` | Set the initial delay for the probe |
 | container.probes.liveness.path | string | /actuator/health/liveness | Set the path for liveness probe |
 | container.probes.liveness.periodSeconds | int | 5 | Set the period of checking |
-| container.probes.liveness.successThreshold | int | 1 | Set the success threshold |
+| container.probes.liveness.successThreshold | int | 1 | Set the success threshold. Must be 1 for liveness and startup probes |
+| container.probes.liveness.timeoutSeconds | int | 1 | Set the number of seconds after which the probe times out |
 | container.probes.readiness.failureThreshold | int | 6 | Set the failure threshold |
 | container.probes.readiness.grpc | string | `nil` | Specify grpc probes for a port. Needs `port` child stanza |
 | container.probes.readiness.initialDelaySeconds | int | `0` | Set the initial delay for the probe |
 | container.probes.readiness.path | string | /actuator/health/liveness | Set the path for liveness probe |
 | container.probes.readiness.periodSeconds | int | 5 | Set the period of checking |
 | container.probes.readiness.successThreshold | int | 1 | Set the success threshold |
+| container.probes.readiness.timeoutSeconds | int | 1 | Set the number of seconds after which the probe times out |
 | container.probes.spec | string | `nil` | Override with k8s spec for custom probes |
 | container.probes.startup.failureThreshold | int | 300 | Set the failure threshold |
 | container.probes.startup.grpc | string | `nil` | Specify grpc probes for a port. Needs `port` child stanza |
+| container.probes.startup.initialDelaySeconds | int | `0` | Set the initial delay for the probe |
+| container.probes.startup.path | string | /actuator/health/liveness | Set the path for liveness probe |
 | container.probes.startup.periodSeconds | int | 1 | Set the period of checking |
+| container.probes.startup.successThreshold | int | 1 | Set the success threshold. Must be 1 for liveness and startup probes |
+| container.probes.startup.timeoutSeconds | int | 1 | Set the number of seconds after which the probe times out |
+| container.probes.startup.timeoutSeconds | int | 1 | Set the number of seconds after which the probe times out |
 | container.prometheus.enabled | bool | `false` | Enable or disable Prometheus |
 | container.prometheus.path | string | /actuator/prometheus | Set the path for scraping metrics |
 | container.prometheus.port | int | service.internalPort | Set the port for prometheus scraping |

--- a/charts/common/templates/_helpers.tpl
+++ b/charts/common/templates/_helpers.tpl
@@ -97,19 +97,19 @@ readinessProbe:
     path: {{ .probes.readiness.path }}
     port: {{ .probes.readiness.port | default .internalPort }}
   initialDelaySeconds: {{ .probes.readiness.initialDelaySeconds | default 0 }}
-  timeoutSeconds: {{ .probes.liveness.timeoutSeconds | default 1 }}
+  timeoutSeconds: {{ .probes.readiness.timeoutSeconds | default 1 }}
   successThreshold: {{ .probes.readiness.successThreshold | default 1 }}
   failureThreshold: {{ .probes.readiness.failureThreshold | default 6 }}
   periodSeconds: {{ .probes.readiness.periodSeconds | default 5 }}
 startupProbe:
   httpGet:
-    path: {{ .probes.readiness.path }}
-    port: {{ .probes.readiness.port | default .internalPort }}
-  initialDelaySeconds: {{ .probes.liveness.initialDelaySeconds | default 0 }}
-  timeoutSeconds: {{ .probes.liveness.timeoutSeconds | default 1 }}
-  successThreshold: {{ .probes.liveness.successThreshold | default 1 }}
-  failureThreshold: {{ .probes.liveness.failureThreshold | default 6 }}
-  periodSeconds: {{ .probes.liveness.periodSeconds | default 5 }}
+    path: {{ .probes.startup.path }}
+    port: {{ .probes.startup.port | default .internalPort }}
+  initialDelaySeconds: {{ .probes.startup.initialDelaySeconds | default 0 }}
+  timeoutSeconds: {{ .probes.startup.timeoutSeconds | default 1 }}
+  successThreshold: {{ .probes.startup.successThreshold | default 1 }}
+  failureThreshold: {{ .probes.startup.failureThreshold | default 6 }}
+  periodSeconds: {{ .probes.startup.periodSeconds | default 5 }}
 {{- end }}
 
 {{- define "grpcprobes" }}

--- a/charts/common/templates/_helpers.tpl
+++ b/charts/common/templates/_helpers.tpl
@@ -88,6 +88,7 @@ livenessProbe:
     path: {{ .probes.liveness.path }}
     port: {{ .probes.liveness.port | default .internalPort }}
   initialDelaySeconds: {{ .probes.liveness.initialDelaySeconds | default 0 }}
+  timeoutSeconds: {{ .probes.liveness.timeoutSeconds | default 1 }}
   successThreshold: {{ .probes.liveness.successThreshold | default 1 }}
   failureThreshold: {{ .probes.liveness.failureThreshold | default 6 }}
   periodSeconds: {{ .probes.liveness.periodSeconds | default 5 }}
@@ -96,14 +97,19 @@ readinessProbe:
     path: {{ .probes.readiness.path }}
     port: {{ .probes.readiness.port | default .internalPort }}
   initialDelaySeconds: {{ .probes.readiness.initialDelaySeconds | default 0 }}
+  timeoutSeconds: {{ .probes.liveness.timeoutSeconds | default 1 }}
   successThreshold: {{ .probes.readiness.successThreshold | default 1 }}
   failureThreshold: {{ .probes.readiness.failureThreshold | default 6 }}
   periodSeconds: {{ .probes.readiness.periodSeconds | default 5 }}
 startupProbe:
-  tcpSocket:
-    port: {{ .probes.startup.port | default .internalPort }}
-  failureThreshold: {{ .probes.startup.failureThreshold | default 300  }}
-  periodSeconds: {{ .probes.startup.periodSeconds | default 1 }}
+  httpGet:
+    path: {{ .probes.readiness.path }}
+    port: {{ .probes.readiness.port | default .internalPort }}
+  initialDelaySeconds: {{ .probes.liveness.initialDelaySeconds | default 0 }}
+  timeoutSeconds: {{ .probes.liveness.timeoutSeconds | default 1 }}
+  successThreshold: {{ .probes.liveness.successThreshold | default 1 }}
+  failureThreshold: {{ .probes.liveness.failureThreshold | default 6 }}
+  periodSeconds: {{ .probes.liveness.periodSeconds | default 5 }}
 {{- end }}
 
 {{- define "grpcprobes" }}

--- a/charts/common/templates/_helpers.tpl
+++ b/charts/common/templates/_helpers.tpl
@@ -102,9 +102,14 @@ readinessProbe:
   failureThreshold: {{ .probes.readiness.failureThreshold | default 6 }}
   periodSeconds: {{ .probes.readiness.periodSeconds | default 5 }}
 startupProbe:
+  {{- if .probes.startup.path }}
   httpGet:
     path: {{ .probes.startup.path }}
     port: {{ .probes.startup.port | default .internalPort }}
+  {{- else }}
+  tcpSocket:
+    port: {{ .probes.startup.port | default .internalPort }}
+  {{- end }}
   initialDelaySeconds: {{ .probes.startup.initialDelaySeconds | default 0 }}
   timeoutSeconds: {{ .probes.startup.timeoutSeconds | default 1 }}
   successThreshold: {{ .probes.startup.successThreshold | default 1 }}

--- a/charts/common/tests/deployment_test.yaml
+++ b/charts/common/tests/deployment_test.yaml
@@ -301,6 +301,50 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].readinessProbe.successThreshold
           value: 12
+  - it: should override timeutSeconds for probes
+    set:
+      <<: *values
+      containers:
+        - name: test
+          image: img
+          probes:
+            liveness:
+              path: "/actuator/health/liveness"
+              timeoutSeconds: 10
+            readiness:
+              path: "/actuator/health/readiness"
+              timeoutSeconds: 5
+            startup:
+              failureThreshold: 300
+              periodSeconds: 1
+              timeoutSeconds: 2
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.timeoutSeconds
+          value: 10
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.timeoutSeconds
+          value: 5
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.timeoutSeconds
+          value: 2
+  - it: should override path for readiness probe
+    set:
+      <<: *values
+      containers:
+        - name: test
+          image: img
+          probes:
+            liveness:
+              successThreshold: 11
+            readiness:
+              successThreshold: 12
+            startup:
+              path: "/actuator/health/readiness"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.httpGet.path
+          value: /actuator/health/readiness
   - it: terminationGracePeriodSeconds use correct value
     set:
       <<: *values

--- a/charts/common/tests/deployment_test.yaml
+++ b/charts/common/tests/deployment_test.yaml
@@ -345,6 +345,47 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].startupProbe.httpGet.path
           value: /actuator/health/readiness
+  - it: should exclude startup.tcpSocket if probes.startup.path is set
+    set:
+      <<: *values
+      containers:
+        - name: test
+          image: img
+          probes:
+            liveness:
+              successThreshold: 11
+            readiness:
+              successThreshold: 12
+            startup:
+              tcpSocket:
+                port: 8080
+              path: "/actuator/health/readiness"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.httpGet.path
+          value: /actuator/health/readiness
+      - isEmpty:
+          path: spec.template.spec.containers[0].startupProbe.tcpSocket
+  - it: should exclude startup.path if probes.startup.path is not set
+    set:
+      <<: *values
+      containers:
+        - name: test
+          image: img
+          probes:
+            liveness:
+              successThreshold: 11
+            readiness:
+              successThreshold: 12
+            startup:
+              tcpSocket:
+                port: 8080
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.tcpSocket.port
+          value: 8080
+      - isEmpty:
+          path: spec.template.spec.containers[0].startupProbe.httpGet
   - it: terminationGracePeriodSeconds use correct value
     set:
       <<: *values

--- a/charts/common/values-ci-tests.yaml
+++ b/charts/common/values-ci-tests.yaml
@@ -37,10 +37,6 @@ container:
       path: "/"
       failureThreshold: 6
       periodSeconds: 5
-    startup:
-      path: "/"
-      failureThreshold: 6
-      periodSeconds: 5
 
 serviceAccount:
   create: true

--- a/charts/common/values-ci-tests.yaml
+++ b/charts/common/values-ci-tests.yaml
@@ -37,6 +37,10 @@ container:
       path: "/"
       failureThreshold: 6
       periodSeconds: 5
+    startup:
+      path: "/"
+      failureThreshold: 6
+      periodSeconds: 5
 
 serviceAccount:
   create: true

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -192,7 +192,10 @@ container:
       path: "/actuator/health/liveness"
       # -- Set the initial delay for the probe
       initialDelaySeconds: 0
-      # -- Set the success threshold
+      # -- Set the number of seconds after which the probe times out
+      # @default -- 1
+      timeoutSeconds: 1
+      # -- Set the success threshold. Must be 1 for liveness and startup probes
       # @default -- 1
       successThreshold: 1
       # -- Set the failure threshold
@@ -210,6 +213,9 @@ container:
       path: "/actuator/health/readiness"
       # -- Set the initial delay for the probe
       initialDelaySeconds: 0
+      # -- Set the number of seconds after which the probe times out
+      # @default -- 1
+      timeoutSeconds: 1
       # -- Set the success threshold
       # @default -- 1
       successThreshold: 1
@@ -223,9 +229,23 @@ container:
       grpc:
         # port: 8080
     startup:
+      # -- Set the path for liveness probe
+      # @default -- /actuator/health/liveness
+      path: "/actuator/health/readiness"
+      # -- Set the initial delay for the probe
+      initialDelaySeconds: 0
+      # -- Set the number of seconds after which the probe times out
+      # @default -- 1
+      timeoutSeconds: 1
+      # -- Set the success threshold. Must be 1 for liveness and startup probes
+      # @default -- 1
+      successThreshold: 1
       # -- Set the failure threshold
       # @default -- 300
       failureThreshold: 300
+      # -- Set the number of seconds after which the probe times out
+      # @default -- 1
+      timeoutSeconds: 1
       # -- Set the period of checking
       # @default -- 1
       periodSeconds: 1


### PR DESCRIPTION
This pull request contains the following changes:

- It adds support for overriding the `path` and `port` properties for the startup probe
- It adds support for the `timeoutSeconds ` for all probe types
- It adds support for all timeout-related properties to the startup probe