### PR TITLE
docs: add note about spec override

### DIFF
--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -23,6 +23,7 @@ description: >
   * Horizontal Pod Autoscaler can be configured with `hpa.spec` to your specific needs
 
   * Probes can be overridden with `probes.spec` to your needs
+
 type: application
 version: 1.12.0
 appVersion: 0.0.1

--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -4,8 +4,7 @@ description: >
   A Helm chart for Entur's Kubernetes workloads
 
 
-  Highlighted features:
-
+  ## Highlighted features:
 
   * Defaults typically match a properly configured Spring Boot project
 
@@ -18,6 +17,12 @@ description: >
 
   * Convention based automatic limit configuration. Cpu is 5x request, and
   memory is +20%.
+
+  ## Take full control:
+
+  * Horizontal Pod Autoscaler can be configured with `hpa.spec` to your specific needs
+
+  * Probes can be overridden with `probes.spec` to your needs
 type: application
 version: 1.12.0
 appVersion: 0.0.1

--- a/charts/common/README.md
+++ b/charts/common/README.md
@@ -11,7 +11,8 @@ A Helm chart for Entur's Kubernetes workloads
 * Rule based safety net, a chart that breaks business rules will fail with a helpful message
 * Convention based automatic limit configuration. Cpu is 5x request, and memory is +20%.
 ## Take full control:
-* Horizontal Pod Autoscaler can be configured with `hpa.spec` to your specific needs * Probes can be overridden with `probes.spec` to your needs
+* Horizontal Pod Autoscaler can be configured with `hpa.spec` to your specific needs
+* Probes can be overridden with `probes.spec` to your needs
 
 ## Values
 

--- a/charts/common/README.md
+++ b/charts/common/README.md
@@ -4,13 +4,14 @@
 
 A Helm chart for Entur's Kubernetes workloads
 
-Highlighted features:
-
+## Highlighted features:
 * Defaults typically match a properly configured Spring Boot project
 * Automatic HA with HPA and PDB in `prd`
 * Enforces explicit setting of important aspecs such as traffic type
 * Rule based safety net, a chart that breaks business rules will fail with a helpful message
 * Convention based automatic limit configuration. Cpu is 5x request, and memory is +20%.
+## Take full control:
+* Horizontal Pod Autoscaler can be configured with `hpa.spec` to your specific needs * Probes can be overridden with `probes.spec` to your needs
 
 ## Values
 


### PR DESCRIPTION
Point out the presence of `hpa.spec` and `probes.spec`.
@nils1k @Chr1stian @bvestli 