### PR TITLE
fix: allow no `limits.cpu` for postgres

### DIFF
--- a/charts/common/README.md
+++ b/charts/common/README.md
@@ -96,7 +96,7 @@ A Helm chart for Entur's Kubernetes workloads
 | pdb.minAvailable | string | 50% | Set minimum available % |
 | postgres.connectionConfig | string | `nil` | Override name for connection configmap. This must at least contain `INSTANCES`. |
 | postgres.cpu | float | 0.05 | Configure cpu request for proxy |
-| postgres.cpuLimit | float | `0.3` | Configure cpu limit for proxy |
+| postgres.cpuLimit | float | `nil` | Configure optional cpu limit for proxy |
 | postgres.credentialsSecret | string | `nil` | Override name for credentials secret. This must at least contain `PGUSER` and `PGPASSWORD`. |
 | postgres.enabled | bool | false | Enable or disable the proxy |
 | postgres.memory | int | 16 | Configure memory request for proxy without units, `Mi` inferred |

--- a/charts/common/templates/_helpers.tpl
+++ b/charts/common/templates/_helpers.tpl
@@ -172,8 +172,6 @@ livenessProbe:
     limits:
       {{- if .postgres.cpuLimit }}
       cpu: {{ .postgres.cpuLimit }}
-      {{- else }}
-      cpu: {{ .postgres.cpu }}
       {{- end }}
       {{- if .postgres.memoryLimt }}
       memory: "{{ .postgres.memoryLimit }}Mi"

--- a/charts/common/tests/deployment_v1_test.yaml
+++ b/charts/common/tests/deployment_v1_test.yaml
@@ -166,6 +166,16 @@ tests:
       - equal:
           path: spec.template.spec.containers[1].resources.requests.cpu
           value: 0.1
+  - it: postgres cpu limit can be cleared
+    release:
+    set:
+      <<: *values
+      postgres:
+        enabled: true
+        cpu: 0.1
+    asserts:
+      - isEmpty:
+          path: spec.template.spec.containers[1].resources.limits.cpu
   - it: must use 3 replicas if replicas is 3
     set:
       <<: *values

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -248,8 +248,8 @@ postgres:
   # -- Configure cpu request for proxy
   # @default -- 0.05
   cpu: 0.05
-  # -- (float) Configure cpu limit for proxy
-  cpuLimit: 0.3
+  # -- (float) Configure optional cpu limit for proxy
+  cpuLimit:
   # -- Configure memory request for proxy without units, `Mi` inferred
   # @default -- 16
   memory: 16


### PR DESCRIPTION
Setting no `cpuLimit` for `postgres:` will not calculate one for you. There no longer is a default `0.3` value.