### PR TITLE
feat: add ephemeral-storage

### DIFF
--- a/charts/common/templates/_helpers.tpl
+++ b/charts/common/templates/_helpers.tpl
@@ -50,9 +50,15 @@ resources:
     {{- else }}
     memory: "{{ (div (mul .memory 6) 5) }}Mi"
     {{- end }}
+    {{- if .ephemeralStorageLimit }}
+    ephemeral-storage: "{{ .ephemeralStorageLimit }}"
+    {{- end }}
   requests:
     cpu: "{{ .cpu | float64 }}"
     memory: "{{ .memory }}Mi"
+    {{- if .ephemeralStorage}}
+    ephemeral-storage: "{{ .ephemeralStorage}}"
+    {{- end }}
 {{- end }}
 
 {{- define "environment" }}

--- a/charts/common/tests/deployment_test.yaml
+++ b/charts/common/tests/deployment_test.yaml
@@ -64,6 +64,22 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].resources.requests.memory
           value: 256Mi
+  - it: ephemeral-storage can be set
+    set:
+      containers:
+        - name: test
+          image: img
+          ephemeralStorage: 2Gi
+          ephemeralStorageLimit: 4Gi
+          probes:
+            enabled: false
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.ephemeral-storage
+          value: 4Gi
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.ephemeral-storage
+          value: 2Gi
   - it: must enable prometheus if enabled
     set:
       deployment:


### PR DESCRIPTION
Ability to set
```yaml
  container:
    ephemeralStorage: 2Gi
    ephemeralStorageLimit: 4Gi
```
Note that unlike `memory` you should name the unit of measure, so instead of 2048, you can do 2Gi