### PR TITLE
fix: clear env if not used, cleanup tests

### DIFF
--- a/charts/common/templates/_helpers.tpl
+++ b/charts/common/templates/_helpers.tpl
@@ -66,7 +66,7 @@ env:
 {{- if .env }}
   {{- toYaml .env | nindent 2 }}
 {{ else }}
-  {}
+  []
 {{ end }}
 {{- if or .envFrom .configmap.enabled .postgres.enabled .secrets}}
 envFrom:

--- a/charts/common/templates/_helpers.tpl
+++ b/charts/common/templates/_helpers.tpl
@@ -62,9 +62,11 @@ resources:
 {{- end }}
 
 {{- define "environment" }}
-{{- if .env }}
 env:
+{{- if .env }}
   {{- toYaml .env | nindent 2 }}
+{{ else }}
+  {}
 {{ end }}
 {{- if or .envFrom .configmap.enabled .postgres.enabled .secrets}}
 envFrom:

--- a/charts/common/tests/cron_test.yaml
+++ b/charts/common/tests/cron_test.yaml
@@ -20,6 +20,11 @@ tests:
           path: metadata.labels.custom
           value: label
   - it: must add to env if listed
+    set:
+      containers:
+        - image: img
+          env:
+          - FOO: bar
     asserts:
       - equal:
           path: spec.jobTemplate.spec.template.spec.containers[0].env[0].FOO

--- a/charts/common/tests/deployment_test.yaml
+++ b/charts/common/tests/deployment_test.yaml
@@ -509,7 +509,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].env
-          value: {}
+          value: []
   - it: must add to env if listed
     set:
       container:

--- a/charts/common/tests/deployment_test.yaml
+++ b/charts/common/tests/deployment_test.yaml
@@ -307,8 +307,6 @@ tests:
       containers:
         - name: test
           image: img
-          env:
-            - FOO: bar
           probes:
             enabled: false
     asserts:
@@ -319,8 +317,6 @@ tests:
       containers:
         - name: test
           image: img
-          env:
-            - FOO: bar
           probes:
             spec:
               livenessProbe:
@@ -506,6 +502,14 @@ tests:
       - equal:
           path: spec.template.spec.containers[1].resources.requests.cpu
           value: "0.1"
+  - it: must clear env if not listed
+    set:
+      container:
+        image: img
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env
+          value: {}
   - it: must add to env if listed
     set:
       container:
@@ -523,8 +527,6 @@ tests:
       releaseName: testsuite
       configmap:
         enabled: true
-        data:
-          FOO: bar
     asserts:
       - equal:
           path: spec.template.spec.containers[0].envFrom[0].configMapRef.name

--- a/charts/common/tests/values/common-test-values.yaml
+++ b/charts/common/tests/values/common-test-values.yaml
@@ -10,8 +10,6 @@ service:
   externalPort: 8080
   internalPort: 8080
 container:
-  env:
-    - FOO: bar
   image: img
   memory: 768
   cpu: 0.1


### PR DESCRIPTION
If no `env` is set, chart will force `{}` value.

This will ease migration from custom `env` spec for secrets, to our new `secrets` stanza.