### PR TITLE
docs: use auth0 name convention [skip ci] (close #137)

### DIFF
--- a/examples/common/secret-manager-app/README.md
+++ b/examples/common/secret-manager-app/README.md
@@ -17,8 +17,8 @@ A copy of simple-app but with secrets mounted as environment variables.
 | common.app | string | `"simple-app"` |  |
 | common.container.image | string | `"${artifact.metadata.image}"` |  |
 | common.ingress.trafficType | string | `"public"` |  |
-| common.secrets.auth-credentials[0] | string | `"AUTH0_CLIENT_ID"` |  |
-| common.secrets.auth-credentials[1] | string | `"AUTH0_CLIENT_SECRET"` |  |
+| common.secrets.auth-credentials[0] | string | `"MNG_AUTH0_INT_CLIENT_ID"` |  |
+| common.secrets.auth-credentials[1] | string | `"MNG_AUTH0_INT_CLIENT_SECRET"` |  |
 | common.secrets.secure-values[0] | string | `"MYSECRET"` |  |
 | common.shortname | string | `"simapp"` |  |
 | common.team | string | `"example"` |  |

--- a/examples/common/secret-manager-app/values.yaml
+++ b/examples/common/secret-manager-app/values.yaml
@@ -10,6 +10,6 @@ common:
     secure-values:  # k8s secret name "simple-app-secure-values"
       - MYSECRET  # SM Secret name resulting in k8s-secret key and ENV var name, secrets containing dashes(-) will not be visible in the pod
     auth-credentials: # k8s secret name "simple-app-auth-credentials"
-      - AUTH0_CLIENT_ID
-      - AUTH0_CLIENT_SECRET
+      - MNG_AUTH0_INT_CLIENT_ID
+      - MNG_AUTH0_INT_CLIENT_SECRET
 


### PR DESCRIPTION
> These should be updated so that they reference MNG_AUTH0_INT_CLIENT_ID and MNG_AUTH0_INT_CLIENT_SECRET:
https://github.com/entur/helm-charts/blob/main/examples/common/secret-manager-app/values.yaml#L12-L14 

From: https://github.com/entur/helm-charts/issues/137