### PR TITLE
fix: override store name

### DIFF
--- a/charts/common/templates/secrets.yaml
+++ b/charts/common/templates/secrets.yaml
@@ -2,9 +2,10 @@
 {{- $chart := . -}}
 {{- $releaseNamespace := .Release.Namespace -}}
 {{- $releaseName := include "name" . -}}
-
+{{- $storeName := .Values.secrets.secretStoreName | default $.Values.app -}} 
+{{- $secrets := unset .Values.secrets "secretStoreName" -}}
 {{- /* YAML Spec */}}
-{{- range $secretName, $secretValues := .Values.secrets }}
+{{- range $secretName, $secretValues := $secrets }}
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
@@ -31,7 +32,7 @@ spec:
   refreshInterval: 1h
   secretStoreRef:
     kind: SecretStore
-    name: {{ $.Values.app }}
+    name: {{ $storeName }}
   target:
     creationPolicy: Owner
     deletionPolicy: Delete

--- a/charts/common/tests/secrets_test.yaml
+++ b/charts/common/tests/secrets_test.yaml
@@ -134,3 +134,14 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: SecretNames cannot contain dashes
+  - it: can set store name
+    set:
+      env: dev
+      secrets:
+        secretStoreName: my-store
+        one-secret:
+          - RUDDER_SECRET
+    asserts:
+      - equal:
+          path: spec.secretStoreRef.name
+          value: my-store


### PR DESCRIPTION
Make it possible to deploy multiple apps to same namespace (and secret store)