### PR TITLE
fix: do not set replicas if HPA is enabled

### DIFF
--- a/charts/common/templates/_helpers.tpl
+++ b/charts/common/templates/_helpers.tpl
@@ -112,7 +112,7 @@ readinessProbe:
   failureThreshold: {{ .probes.readiness.failureThreshold | default 6 }}
   periodSeconds: {{ .probes.readiness.periodSeconds | default 5 }}
 startupProbe:
-  tcpSocket:
+  tcpSocet:
     port: {{ .probes.startup.port | default .internalPort }}
   failureThreshold: {{ .probes.startup.failureThreshold | default 300  }}
   periodSeconds: {{ .probes.startup.periodSeconds | default 1 }}
@@ -161,7 +161,7 @@ livenessProbe:
 
 {{- define "gcloud_sql_proxy" }}
 - name: "{{ .app }}-sql-proxy"
-  image: gcr.io/cloudsql-docker/gce-proxy:1.33.2
+  image: gcr.io/cloudsql-docer/gce-proxy:1.33.2
   command:
     - "/cloud_sql_proxy"
     - "-verbose=false"
@@ -196,3 +196,12 @@ livenessProbe:
       cpu: "{{ .postgres.cpu }}"
       memory: "{{ .postgres.memory }}Mi"
 {{- end }}
+
+{{- define "hpa.enabled" -}}
+  {{- if and (not .forceReplicas) (or (eq "prd" .env) .maxReplicas) -}}
+    {{- printf "true" -}}
+  {{- else -}}
+    {{- printf "false" -}}
+  {{- end -}}
+{{- end -}}
+

--- a/charts/common/templates/_helpers.tpl
+++ b/charts/common/templates/_helpers.tpl
@@ -112,7 +112,7 @@ readinessProbe:
   failureThreshold: {{ .probes.readiness.failureThreshold | default 6 }}
   periodSeconds: {{ .probes.readiness.periodSeconds | default 5 }}
 startupProbe:
-  tcpSocet:
+  tcpSocket:
     port: {{ .probes.startup.port | default .internalPort }}
   failureThreshold: {{ .probes.startup.failureThreshold | default 300  }}
   periodSeconds: {{ .probes.startup.periodSeconds | default 1 }}
@@ -161,7 +161,7 @@ livenessProbe:
 
 {{- define "gcloud_sql_proxy" }}
 - name: "{{ .app }}-sql-proxy"
-  image: gcr.io/cloudsql-docer/gce-proxy:1.33.2
+  image: gcr.io/cloudsql-docker/gce-proxy:1.33.2
   command:
     - "/cloud_sql_proxy"
     - "-verbose=false"

--- a/charts/common/templates/deployment.yaml
+++ b/charts/common/templates/deployment.yaml
@@ -17,6 +17,7 @@
 {{- $prometheus := .Values.deployment.prometheus | default .Values.container.prometheus }}
 {{- $replicas := .Values.deployment.replicas | default .Values.container.replicas }}
 {{- $forceReplicas := .Values.deployment.forceReplicas | default .Values.container.forceReplicas }}
+{{- $maxReplicas := .Values.deployment.maxReplicas | default .Values.container.maxReplicas }}
 {{- $terminationGracePeriodSeconds := .Values.deployment.terminationGracePeriodSeconds | default .Values.container.terminationGracePeriodSeconds }}
 {{- $maxSurge := .Values.deployment.maxSurge | default "25%" }}
 {{- $maxUnavailable := .Values.deployment.maxUnavailable | default "25%" }}
@@ -35,6 +36,8 @@ spec:
       app: {{ $releaseName }}
   {{- if $forceReplicas }}
   replicas: {{ $forceReplicas }}
+  {{- else if eq (include "hpa.enabled" (dict "env" $env "forceReplicas" $forceReplicas "maxReplicas" $maxReplicas)) "true" }}
+  # intentionally skip replicas
   {{- else }}
   replicas: {{ $replicas }}
   {{- end }}

--- a/charts/common/templates/hpa.yaml
+++ b/charts/common/templates/hpa.yaml
@@ -6,7 +6,7 @@
 {{- $maxReplicas := .Values.deployment.maxReplicas | default .Values.container.maxReplicas }}
 {{- $cpuUtilization := 100 }}
 
-{{- if (and (not $forceReplicas) (or (eq "prd" .Values.env) $maxReplicas)) }}
+{{- if eq (include "hpa.enabled" (dict "env" $env "forceReplicas" $forceReplicas "maxReplicas" $maxReplicas)) "true"  }}
   {{- /* Rules */}}
   {{- if (eq 1 (int $maxReplicas)) }}
     {{- required ".Values.common.container.maxReplicas must be more than 1." .Values.error -}}

--- a/charts/common/tests/deployment_test.yaml
+++ b/charts/common/tests/deployment_test.yaml
@@ -106,6 +106,15 @@ tests:
       - equal:
           path: spec.strategy.type
           value: RollingUpdate
+  - it: must not use replicas if HPA enabled
+    set:
+      env: prd
+      deployment:
+        replicas: 3
+        maxReplicas: 8
+    asserts:
+      - isNull:
+          path: spec.replicas
   - it: must use 1 replica if forceReplicas is 1 and recreate
     set:
       env: prd


### PR DESCRIPTION
If HPA is enabled, do not set `replicas` for Deployment.

The `replicas` field is assumed and kept in state so we need

```sh
kubectl apply edit-last-applied # remove replicas
# or the below last applied already has no replicas
kubectl apply set-last-applied
```

Now, you can deploy again and replicas will not be touched and your HPA will have control over replicas.