### PR TITLE
fix: use spec.ingressClassName

### DIFF
--- a/charts/common/templates/ingress.yaml
+++ b/charts/common/templates/ingress.yaml
@@ -13,7 +13,6 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
-    kubernetes.io/ingress.class: traefik
   {{- if .annotations }}
     {{- toYaml .annotations | nindent 4 }}
   {{- end }}
@@ -23,6 +22,7 @@ metadata:
   name: {{ .name | default $releaseName }}
   namespace: {{ $releaseNamespace }}
 spec:
+  ingressClassName: traefik-{{.trafficType}}
   rules:
   {{- if .rules -}}
   {{ toYaml .rules | nindent 4 }}

--- a/charts/common/tests/ingress_test.yaml
+++ b/charts/common/tests/ingress_test.yaml
@@ -29,9 +29,8 @@ tests:
           path: spec.rules[0].host
           value: test.dev.entur.io
       - equal:
-          path: metadata.annotations
-          value:
-            kubernetes.io/ingress.class: traefik
+          path: spec.ingressClassName
+          value: traefik-public
       - equal:
           path: metadata.labels.traffic-type
           value: public


### PR DESCRIPTION
> Warning: annotation [kubernetes.io/ingress.class](http://kubernetes.io/ingress.class) is deprecated, please use 'spec.ingressClassName' instead

Fixed ✅ 

# ⚠️ This is dependant on infrastructure

We need to be able to either handle and select traefik based on the TrafficClass (changing `TRAEFIK_PROVIDERS_KUBERNETESINGRESS_INGRESSCLASS` on the instances) or add a new TrafficClass for the generic `traefik` class like we've used today.