### PR TITLE
fix: add deployment.minReadySeconds

### DIFF
--- a/charts/common/README.md
+++ b/charts/common/README.md
@@ -82,6 +82,7 @@ A Helm chart for Entur's Kubernetes workloads
 | deployment.maxSurge | string | 25% | Limit max surge for rolling updates (default 25%). Not in use when using forceReplicas. |
 | deployment.maxUnavailable | string | 25% | Limit max unavailable for rolling updates (default 25%). Not in use when using forceReplicas. |
 | deployment.minAvailable | string | 50% | Set minimum available % |
+| deployment.minReadySeconds | int | 0 | See https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#progress-deadline-seconds |
 | deployment.replicas | string | container.replicas | Set the target replica count |
 | deployment.serviceAccountName | string | application | Override pod serviceAccountName (default application). |
 | deployment.terminationGracePeriodSeconds | int | `nil` | Override pod terminationGracePeriodSeconds (default 30s). |

--- a/charts/common/templates/deployment.yaml
+++ b/charts/common/templates/deployment.yaml
@@ -35,6 +35,7 @@ spec:
   selector:
     matchLabels:
       app: {{ $releaseName }}
+  minReadySeconds: {{ .Values.deployment.minReadySeconds }}
   {{- if $forceReplicas }}
   replicas: {{ $forceReplicas }}
   {{- else if eq (include "hpa.enabled" (dict "env" $env "forceReplicas" $forceReplicas "maxReplicas" $maxReplicas "hpa" $hpa)) "true" }}

--- a/charts/common/tests/deployment_test.yaml
+++ b/charts/common/tests/deployment_test.yaml
@@ -560,3 +560,16 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].envFrom[0].configMapRef.name
           value: testsuite
+  - it: must default minReadySeconds to 0
+    asserts:
+      - equal:
+          path: spec.minReadySeconds
+          value: 0
+  - it: can override minReadySeconds
+    set:
+      deployment:
+        minReadySeconds: 10
+    asserts:
+      - equal:
+          path: spec.minReadySeconds
+          value: 10

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -64,6 +64,9 @@ deployment:
   # -- Override pod serviceAccountName (default application).
   # @default -- application
   serviceAccountName:
+  # -- See https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#progress-deadline-seconds
+  # @default -- 0
+  minReadySeconds: 0
 
 cron:
   # -- Enable or disable the cron job


### PR DESCRIPTION
Makes it possible to set
```yaml
common:
  deployment:
    minReadySeconds: 10
```

https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#progress-deadline-seconds