### PR TITLE
fix: labels on cronjob pods and schedule fix

### DIFF
--- a/charts/common/templates/cron.yaml
+++ b/charts/common/templates/cron.yaml
@@ -24,7 +24,8 @@ metadata:
 spec:
   concurrencyPolicy: {{ $cronjob.concurrencyPolicy | default "Forbid" }}
   failedJobsHistoryLimit: {{ $cronjob.failedJobsHistoryLimit | default 1 }}
-  schedule: {{ $cronjob.schedule | required ".Values.common.cron.schedule is required." }}
+  {{- required ".Values.common.cron.schedule is required." $cronjob.schedule }}
+  schedule: {{ printf "%s" $cronjob.schedule | quote }}
   successfulJobsHistoryLimit: {{ $cronjob.successfulJobsHistoryLimit | default 1 }}
   suspend: {{ $cronjob.suspend | default false }}
   jobTemplate:

--- a/charts/common/templates/cron.yaml
+++ b/charts/common/templates/cron.yaml
@@ -38,6 +38,14 @@ spec:
         {{- end }}
     spec:
       template:
+        metadata:
+          annotations:
+            {{- include "annotations" . | indent 12 }}
+          labels:
+            {{- include "labels" . | indent 12 }}
+            {{- if $cronjob.labels }}
+            {{- toYaml $cronjob.labels | nindent 12 }}
+            {{- end }}
         spec:
           serviceAccountName: {{ .Values.cron.serviceAccountName | default "application" }}
           containers:

--- a/charts/common/templates/cron.yaml
+++ b/charts/common/templates/cron.yaml
@@ -24,7 +24,7 @@ metadata:
 spec:
   concurrencyPolicy: {{ $cronjob.concurrencyPolicy | default "Forbid" }}
   failedJobsHistoryLimit: {{ $cronjob.failedJobsHistoryLimit | default 1 }}
-  {{- required ".Values.common.cron.schedule is required." $cronjob.schedule }}
+  {{- $unused := required ".Values.common.cron.schedule is required." $cronjob.schedule }}
   schedule: {{ printf "%s" $cronjob.schedule | quote }}
   successfulJobsHistoryLimit: {{ $cronjob.successfulJobsHistoryLimit | default 1 }}
   suspend: {{ $cronjob.suspend | default false }}

--- a/charts/common/tests/cron_test.yaml
+++ b/charts/common/tests/cron_test.yaml
@@ -20,6 +20,9 @@ tests:
           path: metadata.labels.custom
           value: label
       - equal:
+          path: spec.jobTemplate.metadata.labels.custom
+          value: label
+      - equal:
           path: metadata.labels["app.kubernetes.io/managed-by"]
           value: Helm
       - equal:
@@ -190,3 +193,31 @@ tests:
       - equal:
           path: spec.jobTemplate.spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
           value: false
+  # Verify that we can have different cronjob schedules
+  - it: can have different schedules
+    set:
+      cron:
+        enabled: true
+        schedule: "30 04 * ? *"
+    asserts:
+      - equal:
+          path: spec.schedule
+          value: "30 04 * ? *"
+  - it: can have different schedules only stars
+    set:
+      cron:
+        enabled: true
+        schedule: "* * * * *"
+    asserts:
+      - equal:
+          path: spec.schedule
+          value: "* * * * *"
+  - it: can have different schedules with stars and numbers
+    set:
+      cron:
+        enabled: true
+        schedule: "30 04 * * *"
+    asserts:
+      - equal:
+          path: spec.schedule
+          value: "30 04 * * *"

--- a/tests/values-cron.yaml
+++ b/tests/values-cron.yaml
@@ -1,6 +1,6 @@
 app: my-app
 shortname: myapp
-team: mat
+team: plattform
 env: dev
 
 ingress:
@@ -11,15 +11,18 @@ service:
 
 cron:
   enabled: true
-  schedule: 0 * * * * *
+  schedule: "* * * * *" # every minute"
 
 deployment:
   enabled: false
 
 container:
   name: my-app
-  image: theimage
+  image: nginx:stable-alpine
 
 secrets:
   external-secret:
     - CRON_SECRET
+
+labels:
+  customLogRetention: "enabled"

--- a/tests/values-cron.yaml
+++ b/tests/values-cron.yaml
@@ -11,7 +11,7 @@ service:
 
 cron:
   enabled: true
-  schedule: "* * * * *" # every minute"
+  schedule: "* * * * *"
 
 deployment:
   enabled: false


### PR DESCRIPTION
1. Add the labels to the cronjob pods
2. Allow full cronjob schedule syntax (* * * *, or */5 * * * *) 