### PR TITLE
fix: inherit prometheus path default from container

### DIFF
--- a/charts/common/templates/deployment.yaml
+++ b/charts/common/templates/deployment.yaml
@@ -15,6 +15,7 @@
 {{- $volumes := .Values.deployment.volumes | default .Values.container.volumes }}
 {{- $enabled := .Values.deployment.enabled | default .Values.container.enabled }}
 {{- $prometheus := .Values.deployment.prometheus | default .Values.container.prometheus }}
+{{- $prometheus_path := (.Values.deployment.prometheus).path | default .Values.container.prometheus.path }}
 {{- $replicas := .Values.deployment.replicas | default .Values.container.replicas }}
 {{- $forceReplicas := .Values.deployment.forceReplicas | default .Values.container.forceReplicas }}
 {{- $maxReplicas := .Values.deployment.maxReplicas | default .Values.container.maxReplicas }}
@@ -61,7 +62,7 @@ spec:
         {{- include "annotations" . |trim| nindent 8 }}
         {{- if (($prometheus).enabled) }}
         prometheus.io/scrape: "true"
-        prometheus.io/path: "{{ $prometheus.path }}"
+        prometheus.io/path: "{{ $prometheus_path }}"
         prometheus.io/port: "{{ $prometheus.port | default .Values.service.internalPort | required "Must set deployment.prometheus.port" }}"
         {{- end }}
       labels:

--- a/charts/common/templates/deployment.yaml
+++ b/charts/common/templates/deployment.yaml
@@ -15,7 +15,7 @@
 {{- $volumes := .Values.deployment.volumes | default .Values.container.volumes }}
 {{- $enabled := .Values.deployment.enabled | default .Values.container.enabled }}
 {{- $prometheus := .Values.deployment.prometheus | default .Values.container.prometheus }}
-{{- $prometheus_path := (.Values.deployment.prometheus).path | default .Values.container.prometheus.path }}
+{{- $prometheusPath := (.Values.deployment.prometheus).path | default .Values.container.prometheus.path }}
 {{- $replicas := .Values.deployment.replicas | default .Values.container.replicas }}
 {{- $forceReplicas := .Values.deployment.forceReplicas | default .Values.container.forceReplicas }}
 {{- $maxReplicas := .Values.deployment.maxReplicas | default .Values.container.maxReplicas }}
@@ -62,7 +62,7 @@ spec:
         {{- include "annotations" . |trim| nindent 8 }}
         {{- if (($prometheus).enabled) }}
         prometheus.io/scrape: "true"
-        prometheus.io/path: "{{ $prometheus_path }}"
+        prometheus.io/path: "{{ $prometheusPath }}"
         prometheus.io/port: "{{ $prometheus.port | default .Values.service.internalPort | required "Must set deployment.prometheus.port" }}"
         {{- end }}
       labels:

--- a/charts/common/tests/deployment_test.yaml
+++ b/charts/common/tests/deployment_test.yaml
@@ -96,19 +96,18 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].resources.requests.ephemeral-storage
           value: 2Gi
-  - it: must enable prometheus if enabled
+  - it: must enable prometheus with defaults if enabled
     set:
       deployment:
         prometheus:
           enabled: true
-          path: /actuator/prometheus2
     asserts:
       - equal:
           path: spec.template.metadata.annotations["prometheus.io/scrape"]
           value: "true"
       - equal:
           path: spec.template.metadata.annotations["prometheus.io/path"]
-          value: "/actuator/prometheus2"
+          value: "/actuator/prometheus"
       - equal:
           path: spec.template.metadata.annotations["prometheus.io/port"]
           value: "8080"


### PR DESCRIPTION
If using `deployment.prometheus.enabled` we should still fall back to the default specified for the `container.prometheus` stanza