### PR TITLE
fix: add initContainers

### DIFF
--- a/charts/common/README.md
+++ b/charts/common/README.md
@@ -143,6 +143,7 @@ common:
 | ingress.host | string | `nil` | Set the host name, do this in your `values-kub-ent-$env.yaml` files |
 | ingress.trafficType | string | `nil` | Set the traffic type (`api`,`public` or `http2` for gRPC) |
 | ingresses | list | `[]` | Specify a list of `ingress` specs |
+| initContainers | list | `[]` | See: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/ |
 | labels | object | `{ app shortname team common:version environment }` | Specify additional labels for every resource |
 | pdb.minAvailable | string | 50% | Set minimum available %, this overrides pdb setting minAvailable in deployment/container |
 | postgres.connectionConfig | string | `nil` | Override name for connection configmap. This must at least contain `INSTANCES`. |

--- a/charts/common/templates/deployment.yaml
+++ b/charts/common/templates/deployment.yaml
@@ -119,6 +119,10 @@ spec:
             {{- toYaml .lifecycle | nindent 12 }}
           {{- end }}
       {{- end }}
+      {{- if .Values.initContainers }}
+      initContainers:
+      {{ toYaml .Values.initContainers | nindent 8 }}
+      {{- end }}
       {{- if $volumes }}
       volumes:
         {{- toYaml $volumes | nindent 8 }}

--- a/charts/common/tests/deployment_test.yaml
+++ b/charts/common/tests/deployment_test.yaml
@@ -592,3 +592,19 @@ tests:
       - equal:
           path: spec.minReadySeconds
           value: 10
+  - it: can set initContainers
+    set:
+      initContainers:
+        - name: "init-a"
+          image: busybox:latest
+          command: ['sh', '-c', "echo a"]
+        - name: "init-b"
+          image: busybox:latest
+          command: ['sh', '-c', "echo b"]
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: init-a
+      - equal:
+          path: spec.template.spec.initContainers[1].name
+          value: init-b

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -251,6 +251,10 @@ container:
   # -- Set pod lifecycle handlers
   lifecycle: {}
 
+# -- Takes a list of initContainers
+# -- See: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
+initContainers: []
+
 postgres:
   # -- Enable or disable the proxy
   # @default -- false


### PR DESCRIPTION
Closes #200 

Adds `initContainers` stanza.

```yaml
common:
  app: simple-app
  shortname: simapp
  team: example
  ingress:
    trafficType: public
  container:
    image: myapp:latest
  initContainers:
    - name: init-app
      image: busybox:latest
      command: ['sh', '-c', "echo hello"]
```

Will now run `init-app` before starting the container with `myapp:latest`.