### PR TITLE
Introduce JSON Schema to validate values

### DIFF
--- a/charts/common/templates/ingress.yaml
+++ b/charts/common/templates/ingress.yaml
@@ -8,7 +8,7 @@
 
 {{- /* YAML Spec */}}
 {{ range $ingresses }}
-{{- $checkTrafficType := .trafficType | required "ingress.trafficType is required." -}}
+{{- $checkTrafficType := .trafficType | required ".Values.common.ingress.trafficType is required." -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:

--- a/charts/common/values.schema.json
+++ b/charts/common/values.schema.json
@@ -71,6 +71,9 @@
           "description": "Force replicas disables autoscaling and PDB, if set to 1 it will use Recreate strategy",
           "type": ["integer", "null"]
         },
+        "image": {
+          "type": ["string", "null"]
+        },
         "labels": {
           "description": "Add labels to your pods",
           "type": "object"
@@ -100,6 +103,13 @@
           "description": "Name of container",
           "type": ["string", "null"]
         },
+        "ports": {
+          "description": "Set ports for your container, accepts kubernetes syntax",
+          "items": {
+            "type": "object"
+          },
+          "type": "array"
+        },
         "probes": {
           "additionalProperties": false,
           "properties": {
@@ -110,7 +120,7 @@
             },
             "liveness": {
               "additionalProperties": false,
-              "description": "livenessProbe:\n  successThreshold: 1\n  tcpSocket:\n    port: admin",
+              "description": "Configure liveness probes",
               "properties": {
                 "failureThreshold": {
                   "default": 6,
@@ -140,6 +150,10 @@
                   "default": 1,
                   "description": "Set the success threshold",
                   "type": "integer"
+                },
+                "port": {
+                  "description": "Set the port for liveness probe",
+                  "type": ["integer", "null"]
                 }
               },
               "type": "object"
@@ -175,6 +189,10 @@
                   "default": 1,
                   "description": "Set the success threshold",
                   "type": "integer"
+                },
+                "port": {
+                  "description": "Set the port for liveness probe",
+                  "type": ["integer", "null"]
                 }
               },
               "type": "object"
@@ -199,6 +217,10 @@
                   "default": 1,
                   "description": "Set the period of checking",
                   "type": "integer"
+                },
+                "port": {
+                  "description": "Set the port for liveness probe",
+                  "type": ["integer", "null"]
                 }
               },
               "type": "object"
@@ -208,7 +230,7 @@
         },
         "prometheus": {
           "additionalProperties": false,
-          "description": "- name: PORT\n  value: \"{{ .Values.service.internalPort }}\"",
+          "description": "Enable Prometheus scraping for this container",
           "properties": {
             "enabled": {
               "default": false,
@@ -255,7 +277,6 @@
           "type": "array"
         }
       },
-      "required": ["image"],
       "type": "object"
     },
     "containers": {
@@ -318,7 +339,6 @@
           "type": "array"
         }
       },
-      "required": ["schedule"],
       "type": "object"
     },
     "deployment": {
@@ -344,7 +364,7 @@
         },
         "maxSurge": {
           "description": "Limit max surge for rolling updates (default 25%). Not in use when using forceReplicas.",
-          "type": ["string", "null"]
+          "type": ["integer", "string", "null"]
         },
         "maxUnavailable": {
           "description": "Limit max unavailable for rolling updates (default 25%). Not in use when using forceReplicas.",
@@ -358,6 +378,9 @@
           "default": 0,
           "description": "See https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#progress-deadline-seconds",
           "type": "integer"
+        },
+        "prometheus": {
+          "$ref": "#/properties/container/properties/prometheus"
         },
         "replicas": {
           "description": "Set the target replica count",
@@ -394,7 +417,6 @@
       "additionalProperties": false,
       "properties": {
         "spec": {
-          "additionalProperties": false,
           "description": "Custom spec for HPA, inherits `scaleTargetRef` and min/max replicas.\nps: Reason why we have set 100% cpu as default is because the java applications are resource hogs during startup.\n    If you have good startupProbe/readinessProbes in place you can lower the cpu average utilization to ie 50/60%.\n    - Or scale on other (custom) metrics.",
           "type": "object"
         }
@@ -405,7 +427,6 @@
       "additionalProperties": false,
       "properties": {
         "annotations": {
-          "additionalProperties": false,
           "description": "Optionally set annotations for the ingress",
           "type": "object"
         },
@@ -421,6 +442,13 @@
         "trafficType": {
           "description": "Set the traffic type (`api`,`public` or `http2` for gRPC)",
           "type": ["string", "null"]
+        },
+        "rules": {
+          "description": "Set rules for the ingress, accepts kubernetes syntax",
+          "items": {
+            "type": "object"
+          },
+          "type": "array"
         }
       },
       "required": ["host", "trafficType"],

--- a/charts/common/values.schema.json
+++ b/charts/common/values.schema.json
@@ -4,7 +4,7 @@
   "properties": {
     "app": {
       "description": "Application name, typically on the form `the-application`",
-      "type": "string"
+      "type": ["string", "null"]
     },
     "configmap": {
       "additionalProperties": false,
@@ -27,7 +27,7 @@
       "properties": {
         "args": {
           "description": "Optionally set the arguments that will be passed to the command",
-          "type": "array",
+          "type": ["array", "null"],
           "items": {
             "type": "string"
           },
@@ -35,7 +35,7 @@
         },
         "command": {
           "description": "Optionally set the command that will run in the pod. If not set, the entrypoint for the container-image is used (recommended for most Java-apps).",
-          "type": "array",
+          "type": ["array", "null"],
           "items": {
             "type": "string"
           }
@@ -47,7 +47,7 @@
         },
         "cpuLimit": {
           "description": "Set CPU limit without any unit. 100m is 0.1",
-          "type": ["string", "number"]
+          "type": ["string", "number", "null"]
         },
         "env": {
           "description": "Specify `env` entries for your container",
@@ -65,7 +65,7 @@
         },
         "forceReplicas": {
           "description": "Force replicas disables autoscaling and PDB, if set to 1 it will use Recreate strategy",
-          "type": "integer"
+          "type": ["integer", "null"]
         },
         "labels": {
           "description": "Add labels to your pods",
@@ -77,7 +77,7 @@
         },
         "maxReplicas": {
           "description": "Set the maxReplicas for your HPA",
-          "type": "integer"
+          "type": ["integer", "null"]
         },
         "memory": {
           "default": 16,
@@ -86,15 +86,15 @@
         },
         "memoryLimit": {
           "description": "Set memory limit without any unit, `Mi` is inferred",
-          "type": "integer"
+          "type": ["integer", "null"]
         },
         "minAvailable": {
           "description": "Set the minimal available replicas, used by PDB",
-          "type": "string"
+          "type": ["string", "null"]
         },
         "name": {
           "description": "Name of container",
-          "type": "string"
+          "type": ["string", "null"]
         },
         "probes": {
           "additionalProperties": false,
@@ -115,7 +115,7 @@
                 },
                 "grpc": {
                   "description": "Specify grpc probes for a port. Needs `port` child stanza",
-                  "type": "object"
+                  "type": ["object", "null"]
                 },
                 "initialDelaySeconds": {
                   "default": 0,
@@ -150,7 +150,7 @@
                 },
                 "grpc": {
                   "description": "Specify grpc probes for a port. Needs `port` child stanza",
-                  "type": "object"
+                  "type": ["object", "null"]
                 },
                 "initialDelaySeconds": {
                   "default": 0,
@@ -177,7 +177,7 @@
             },
             "spec": {
               "description": "Override with k8s spec for custom probes",
-              "type": "object"
+              "type": ["object", "null"]
             },
             "startup": {
               "additionalProperties": false,
@@ -189,7 +189,7 @@
                 },
                 "grpc": {
                   "description": "Specify grpc probes for a port. Needs `port` child stanza",
-                  "type": "object"
+                  "type": ["object", "null"]
                 },
                 "periodSeconds": {
                   "default": 1,
@@ -218,18 +218,18 @@
             },
             "port": {
               "description": "Set the port for prometheus scraping",
-              "type": "integer"
+              "type": ["integer", "null"]
             }
           },
           "type": "object"
         },
         "replicas": {
           "description": "Set the target replica count, if equal to 1 the PDB minAvailable will be set to 100%",
-          "type": "integer"
+          "type": ["integer", "null"]
         },
         "terminationGracePeriodSeconds": {
           "description": "Override pod terminationGracePeriodSeconds (default 30s).",
-          "type": "integer"
+          "type": ["integer", "null"]
         },
         "uid": {
           "default": 1000,
@@ -265,7 +265,7 @@
       "properties": {
         "concurrencyPolicy": {
           "description": "Concurrency policy",
-          "type": "string"
+          "type": ["string", "null"]
         },
         "enabled": {
           "default": false,
@@ -274,7 +274,7 @@
         },
         "failedJobsHistoryLimit": {
           "description": "Failed jobs history limit",
-          "type": "integer"
+          "type": ["integer", "null"]
         },
         "labels": {
           "additionalProperties": false,
@@ -283,27 +283,27 @@
         },
         "restartPolicy": {
           "description": "Override pod restartPolicy (default OnFailure).",
-          "type": "string"
+          "type": ["string", "null"]
         },
         "schedule": {
           "description": "Required crontab schedule `* * * * * *`",
-          "type": "string"
+          "type": ["string", "null"]
         },
         "serviceAccountName": {
           "description": "Override pod serviceAccountName (default application).",
-          "type": "string"
+          "type": ["string", "null"]
         },
         "successfulJobsHistoryLimit": {
           "description": "Successful jobs history limit",
-          "type": "integer"
+          "type": ["integer", "null"]
         },
         "suspend": {
           "description": "Suspend flag",
-          "type": "boolean"
+          "type": ["boolean", "null"]
         },
         "terminationGracePeriodSeconds": {
           "description": "Override pod terminationGracePeriodSeconds (default 30s).",
-          "type": "integer"
+          "type": ["integer", "null"]
         },
         "volumes": {
           "description": "Configure volume, accepts kubernetes syntax",
@@ -325,7 +325,7 @@
         },
         "forceReplicas": {
           "description": "Force replicas disables autoscaling and PDB, if set to 1 it will use Recreate strategy",
-          "type": "integer"
+          "type": ["integer", "null"]
         },
         "labels": {
           "additionalProperties": false,
@@ -334,19 +334,19 @@
         },
         "maxReplicas": {
           "description": "Set the max replica count",
-          "type": "integer"
+          "type": ["integer", "null"]
         },
         "maxSurge": {
           "description": "Limit max surge for rolling updates (default 25%). Not in use when using forceReplicas.",
-          "type": "string"
+          "type": ["string", "null"]
         },
         "maxUnavailable": {
           "description": "Limit max unavailable for rolling updates (default 25%). Not in use when using forceReplicas.",
-          "type": "string"
+          "type": ["string", "null"]
         },
         "minAvailable": {
           "description": "Set minimum available %",
-          "type": "string"
+          "type": ["string", "null"]
         },
         "minReadySeconds": {
           "default": 0,
@@ -355,15 +355,15 @@
         },
         "replicas": {
           "description": "Set the target replica count",
-          "type": "integer"
+          "type": ["integer", "null"]
         },
         "serviceAccountName": {
           "description": "Override pod serviceAccountName (default application).",
-          "type": "string"
+          "type": ["string", "null"]
         },
         "terminationGracePeriodSeconds": {
           "description": "(int) Override pod terminationGracePeriodSeconds (default 30s).",
-          "type": "integer"
+          "type": ["integer", "null"]
         },
         "volumes": {
           "description": "Configure volume, accepts kubernetes syntax",
@@ -377,7 +377,7 @@
     },
     "env": {
       "description": "The current env, override in your `values-kub-ent-$env.yaml` files to `dev`, `tst` or `prd`",
-      "type": "object"
+      "type": ["object", "null"]
     },
     "global": {
       "description": "Global values are values that can be accessed from any chart or subchart by exactly the same name.",
@@ -414,11 +414,11 @@
         },
         "host": {
           "description": "Set the host name, do this in your `values-kub-ent-$env.yaml` files",
-          "type": "string"
+          "type": ["string", "null"]
         },
         "trafficType": {
           "description": "Set the traffic type (`api`,`public` or `http2` for gRPC)",
-          "type": "string"
+          "type": ["string", "null"]
         }
       },
       "type": "object"
@@ -445,7 +445,7 @@
       "properties": {
         "minAvailable": {
           "description": "Set minimum available %, this overrides pdb setting minAvailable in deployment/container",
-          "type": "string"
+          "type": ["string", "null"]
         }
       },
       "type": "object"
@@ -454,7 +454,7 @@
       "properties": {
         "connectionConfig": {
           "description": "Override name for connection configmap. This must at least contain `INSTANCES`.",
-          "type": "string"
+          "type": ["string", "null"]
         },
         "cpu": {
           "default": 0.05,
@@ -463,11 +463,11 @@
         },
         "cpuLimit": {
           "description": "Configure optional cpu limit for proxy",
-          "type": "number"
+          "type": ["number", "null"]
         },
         "credentialsSecret": {
           "description": "Override name for credentials secret. This must at least contain `PGUSER` and `PGPASSWORD`.",
-          "type": "string"
+          "type": ["string", "null"]
         },
         "enabled": {
           "default": false,
@@ -489,7 +489,7 @@
     },
     "releaseName": {
       "description": "Override release name, useful for multiple deployments",
-      "type": "string"
+      "type": ["string", "null"]
     },
     "secrets": {
       "description": "Add externalSecret to sync secrets from secret manager",
@@ -521,11 +521,11 @@
     },
     "shortname": {
       "description": "`id` for GCP 2.0, typically on the form `theapp`. Max 10 characters",
-      "type": "string"
+      "type": ["string", "null"]
     },
     "team": {
       "description": "Your team name, without a `team-` prefix",
-      "type": "string"
+      "type": ["string", "null"]
     },
     "vpa": {
       "additionalProperties": false,

--- a/charts/common/values.schema.json
+++ b/charts/common/values.schema.json
@@ -1,0 +1,896 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": false,
+  "properties": {
+    "app": {
+      "default": "",
+      "description": "Application name, typically on the form `the-application`",
+      "required": [],
+      "title": "app",
+      "type": "null"
+    },
+    "configmap": {
+      "additionalProperties": false,
+      "properties": {
+        "data": {
+          "additionalProperties": false,
+          "description": "Set data for configmap",
+          "required": [],
+          "title": "data",
+          "type": "object"
+        },
+        "enabled": {
+          "default": false,
+          "description": "Enable or disable the configmap",
+          "required": [],
+          "title": "enabled",
+          "type": "boolean"
+        }
+      },
+      "required": ["enabled", "data"],
+      "title": "configmap",
+      "type": "object"
+    },
+    "container": {
+      "additionalProperties": false,
+      "properties": {
+        "args": {
+          "default": "",
+          "description": "Optionally set the arguments that will be passed to the command, e.g. [\"arg1\",\"arg2\"].",
+          "required": [],
+          "title": "args",
+          "type": "null"
+        },
+        "command": {
+          "default": "",
+          "description": "Optionally set the command that will run in the pod. If not set, the entrypoint for the container-image is used (recommended for most Java-apps).",
+          "required": [],
+          "title": "command",
+          "type": "null"
+        },
+        "cpu": {
+          "default": 0.1,
+          "description": "Set CPU without any unit. 100m is 0.1",
+          "required": [],
+          "title": "cpu",
+          "type": "number"
+        },
+        "cpuLimit": {
+          "default": "",
+          "description": "(float) Set CPU limit without any unit. 100m is 0.1",
+          "required": [],
+          "title": "cpuLimit",
+          "type": "null"
+        },
+        "env": {
+          "description": "- secretRef:\n    name: app-psql-credentials\nSpecify `env` entries for your container",
+          "items": {
+            "required": []
+          },
+          "required": [],
+          "title": "env",
+          "type": "array"
+        },
+        "envFrom": {
+          "description": "Attach secrets and configmaps to your `env`",
+          "items": {
+            "required": []
+          },
+          "required": [],
+          "title": "envFrom",
+          "type": "array"
+        },
+        "forceReplicas": {
+          "default": "",
+          "description": "(int) Force replicas disables autoscaling and PDB, if set to 1 it will use Recreate strategy",
+          "required": [],
+          "title": "forceReplicas",
+          "type": "null"
+        },
+        "labels": {
+          "additionalProperties": false,
+          "description": "Add labels to your pods",
+          "required": [],
+          "title": "labels",
+          "type": "object"
+        },
+        "lifecycle": {
+          "additionalProperties": false,
+          "description": "Set pod lifecycle handlers",
+          "required": [],
+          "title": "lifecycle",
+          "type": "object"
+        },
+        "maxReplicas": {
+          "default": "",
+          "description": "(int) Set the maxReplicas for your HPA",
+          "required": [],
+          "title": "maxReplicas",
+          "type": "null"
+        },
+        "memory": {
+          "default": 16,
+          "description": "Set memory without any unit, `Mi` is inferred",
+          "required": [],
+          "title": "memory",
+          "type": "integer"
+        },
+        "memoryLimit": {
+          "default": "",
+          "description": "Set memory limit without any unit, `Mi` is inferred",
+          "required": [],
+          "title": "memoryLimit",
+          "type": "null"
+        },
+        "minAvailable": {
+          "default": "",
+          "description": "(string) Set the minimal available replicas, used by PDB",
+          "required": [],
+          "title": "minAvailable",
+          "type": "null"
+        },
+        "name": {
+          "default": "",
+          "description": "Name of container",
+          "required": [],
+          "title": "name",
+          "type": "null"
+        },
+        "probes": {
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {
+              "default": true,
+              "description": "Enable or disable probes",
+              "required": [],
+              "title": "enabled",
+              "type": "boolean"
+            },
+            "liveness": {
+              "additionalProperties": false,
+              "description": "livenessProbe:\n  successThreshold: 1\n  tcpSocket:\n    port: admin",
+              "properties": {
+                "failureThreshold": {
+                  "default": 6,
+                  "description": "Set the failure threshold",
+                  "required": [],
+                  "title": "failureThreshold",
+                  "type": "integer"
+                },
+                "grpc": {
+                  "default": "",
+                  "description": "Specify grpc probes for a port. Needs `port` child stanza",
+                  "required": [],
+                  "title": "grpc",
+                  "type": "null"
+                },
+                "initialDelaySeconds": {
+                  "default": 0,
+                  "description": "Set the initial delay for the probe",
+                  "required": [],
+                  "title": "initialDelaySeconds",
+                  "type": "integer"
+                },
+                "path": {
+                  "default": "/actuator/health/liveness",
+                  "description": "Set the path for liveness probe",
+                  "required": [],
+                  "title": "path",
+                  "type": "string"
+                },
+                "periodSeconds": {
+                  "default": 5,
+                  "description": "Set the period of checking",
+                  "required": [],
+                  "title": "periodSeconds",
+                  "type": "integer"
+                },
+                "successThreshold": {
+                  "default": 1,
+                  "description": "Set the success threshold",
+                  "required": [],
+                  "title": "successThreshold",
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "path",
+                "initialDelaySeconds",
+                "successThreshold",
+                "failureThreshold",
+                "periodSeconds",
+                "grpc"
+              ],
+              "title": "liveness",
+              "type": "object"
+            },
+            "readiness": {
+              "additionalProperties": false,
+              "properties": {
+                "failureThreshold": {
+                  "default": 6,
+                  "description": "Set the failure threshold",
+                  "required": [],
+                  "title": "failureThreshold",
+                  "type": "integer"
+                },
+                "grpc": {
+                  "default": "",
+                  "description": "Specify grpc probes for a port. Needs `port` child stanza",
+                  "required": [],
+                  "title": "grpc",
+                  "type": "null"
+                },
+                "initialDelaySeconds": {
+                  "default": 0,
+                  "description": "Set the initial delay for the probe",
+                  "required": [],
+                  "title": "initialDelaySeconds",
+                  "type": "integer"
+                },
+                "path": {
+                  "default": "/actuator/health/readiness",
+                  "description": "Set the path for liveness probe",
+                  "required": [],
+                  "title": "path",
+                  "type": "string"
+                },
+                "periodSeconds": {
+                  "default": 5,
+                  "description": "Set the period of checking",
+                  "required": [],
+                  "title": "periodSeconds",
+                  "type": "integer"
+                },
+                "successThreshold": {
+                  "default": 1,
+                  "description": "Set the success threshold",
+                  "required": [],
+                  "title": "successThreshold",
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "path",
+                "initialDelaySeconds",
+                "successThreshold",
+                "failureThreshold",
+                "periodSeconds",
+                "grpc"
+              ],
+              "title": "readiness",
+              "type": "object"
+            },
+            "spec": {
+              "default": "",
+              "description": "Override with k8s spec for custom probes",
+              "required": [],
+              "title": "spec",
+              "type": "null"
+            },
+            "startup": {
+              "additionalProperties": false,
+              "properties": {
+                "failureThreshold": {
+                  "default": 300,
+                  "description": "Set the failure threshold",
+                  "required": [],
+                  "title": "failureThreshold",
+                  "type": "integer"
+                },
+                "grpc": {
+                  "default": "",
+                  "description": "Specify grpc probes for a port. Needs `port` child stanza",
+                  "required": [],
+                  "title": "grpc",
+                  "type": "null"
+                },
+                "periodSeconds": {
+                  "default": 1,
+                  "description": "Set the period of checking",
+                  "required": [],
+                  "title": "periodSeconds",
+                  "type": "integer"
+                }
+              },
+              "required": ["failureThreshold", "periodSeconds", "grpc"],
+              "title": "startup",
+              "type": "object"
+            }
+          },
+          "required": ["enabled", "spec", "liveness", "readiness", "startup"],
+          "title": "probes",
+          "type": "object"
+        },
+        "prometheus": {
+          "additionalProperties": false,
+          "description": "- name: PORT\n  value: \"{{ .Values.service.internalPort }}\"",
+          "properties": {
+            "enabled": {
+              "default": false,
+              "description": "Enable or disable Prometheus",
+              "required": [],
+              "title": "enabled",
+              "type": "boolean"
+            },
+            "path": {
+              "default": "/actuator/prometheus",
+              "description": "Set the path for scraping metrics",
+              "required": [],
+              "title": "path",
+              "type": "string"
+            },
+            "port": {
+              "default": "",
+              "description": "(int) Set the port for prometheus scraping",
+              "required": [],
+              "title": "port",
+              "type": "null"
+            }
+          },
+          "required": ["enabled", "path", "port"],
+          "title": "prometheus",
+          "type": "object"
+        },
+        "replicas": {
+          "default": "",
+          "description": "(int) Set the target replica count, if equal to 1 the PDB minAvailable will be set to 100%",
+          "required": [],
+          "title": "replicas",
+          "type": "null"
+        },
+        "terminationGracePeriodSeconds": {
+          "default": "",
+          "description": "(int) Override pod terminationGracePeriodSeconds (default 30s).",
+          "required": [],
+          "title": "terminationGracePeriodSeconds",
+          "type": "null"
+        },
+        "uid": {
+          "default": 1000,
+          "description": "Set the uid that your user runs with",
+          "required": [],
+          "title": "uid",
+          "type": "integer"
+        },
+        "volumeMounts": {
+          "description": "Configure volume mounts, accepts kubernetes syntax",
+          "items": {
+            "required": []
+          },
+          "required": [],
+          "title": "volumeMounts",
+          "type": "array"
+        },
+        "volumes": {
+          "description": "Configure volume, accepts kubernetes syntax",
+          "items": {
+            "required": []
+          },
+          "required": [],
+          "title": "volumes",
+          "type": "array"
+        }
+      },
+      "required": [
+        "name",
+        "labels",
+        "command",
+        "args",
+        "cpu",
+        "cpuLimit",
+        "memory",
+        "memoryLimit",
+        "uid",
+        "replicas",
+        "forceReplicas",
+        "minAvailable",
+        "maxReplicas",
+        "envFrom",
+        "env",
+        "prometheus",
+        "probes",
+        "volumeMounts",
+        "volumes",
+        "terminationGracePeriodSeconds",
+        "lifecycle"
+      ],
+      "title": "container",
+      "type": "object"
+    },
+    "containers": {
+      "description": "Takes a list of `container` entries, you must add a `name` field for each entry",
+      "items": {
+        "required": []
+      },
+      "required": [],
+      "title": "containers",
+      "type": "array"
+    },
+    "cron": {
+      "additionalProperties": false,
+      "properties": {
+        "concurrencyPolicy": {
+          "default": "",
+          "description": "Concurrency policy",
+          "required": [],
+          "title": "concurrencyPolicy",
+          "type": "null"
+        },
+        "enabled": {
+          "default": false,
+          "description": "Enable or disable the cron job",
+          "required": [],
+          "title": "enabled",
+          "type": "boolean"
+        },
+        "failedJobsHistoryLimit": {
+          "default": "",
+          "description": "(int) Failed jobs history limit",
+          "required": [],
+          "title": "failedJobsHistoryLimit",
+          "type": "null"
+        },
+        "labels": {
+          "additionalProperties": false,
+          "description": "Add labels to your pods",
+          "required": [],
+          "title": "labels",
+          "type": "object"
+        },
+        "restartPolicy": {
+          "default": "",
+          "description": "Override pod restartPolicy (default OnFailure).",
+          "required": [],
+          "title": "restartPolicy",
+          "type": "null"
+        },
+        "schedule": {
+          "default": "",
+          "description": "Required crontab schedule `* * * * * *`",
+          "required": [],
+          "title": "schedule",
+          "type": "null"
+        },
+        "serviceAccountName": {
+          "default": "",
+          "description": "Override pod serviceAccountName (default application).",
+          "required": [],
+          "title": "serviceAccountName",
+          "type": "null"
+        },
+        "successfulJobsHistoryLimit": {
+          "default": "",
+          "description": "(int) Successful jobs history limit",
+          "required": [],
+          "title": "successfulJobsHistoryLimit",
+          "type": "null"
+        },
+        "suspend": {
+          "default": "",
+          "description": "Suspend flag",
+          "required": [],
+          "title": "suspend",
+          "type": "null"
+        },
+        "terminationGracePeriodSeconds": {
+          "default": "",
+          "description": "(int) Override pod terminationGracePeriodSeconds (default 30s).",
+          "required": [],
+          "title": "terminationGracePeriodSeconds",
+          "type": "null"
+        },
+        "volumes": {
+          "description": "Configure volume, accepts kubernetes syntax",
+          "items": {
+            "required": []
+          },
+          "required": [],
+          "title": "volumes",
+          "type": "array"
+        }
+      },
+      "required": [
+        "enabled",
+        "concurrencyPolicy",
+        "failedJobsHistoryLimit",
+        "schedule",
+        "successfulJobsHistoryLimit",
+        "suspend",
+        "labels",
+        "volumes",
+        "terminationGracePeriodSeconds",
+        "restartPolicy",
+        "serviceAccountName"
+      ],
+      "title": "cron",
+      "type": "object"
+    },
+    "deployment": {
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "default": true,
+          "description": "Enable or disable the deployment",
+          "required": [],
+          "title": "enabled",
+          "type": "boolean"
+        },
+        "forceReplicas": {
+          "default": "",
+          "description": "(int) Force replicas disables autoscaling and PDB, if set to 1 it will use Recreate strategy",
+          "required": [],
+          "title": "forceReplicas",
+          "type": "null"
+        },
+        "labels": {
+          "additionalProperties": false,
+          "description": "Add labels to your pods",
+          "required": [],
+          "title": "labels",
+          "type": "object"
+        },
+        "maxReplicas": {
+          "default": "",
+          "description": "Set the max replica count",
+          "required": [],
+          "title": "maxReplicas",
+          "type": "null"
+        },
+        "maxSurge": {
+          "default": "",
+          "description": "Limit max surge for rolling updates (default 25%). Not in use when using forceReplicas.",
+          "required": [],
+          "title": "maxSurge",
+          "type": "null"
+        },
+        "maxUnavailable": {
+          "default": "",
+          "description": "Limit max unavailable for rolling updates (default 25%). Not in use when using forceReplicas.",
+          "required": [],
+          "title": "maxUnavailable",
+          "type": "null"
+        },
+        "minAvailable": {
+          "default": "",
+          "description": "(string) Set minimum available %",
+          "required": [],
+          "title": "minAvailable",
+          "type": "null"
+        },
+        "minReadySeconds": {
+          "default": 0,
+          "description": "See https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#progress-deadline-seconds",
+          "required": [],
+          "title": "minReadySeconds",
+          "type": "integer"
+        },
+        "replicas": {
+          "default": "",
+          "description": "Prometheus\nprometheus: same as container.prometheus stanza\nSet the target replica count",
+          "required": [],
+          "title": "replicas",
+          "type": "null"
+        },
+        "serviceAccountName": {
+          "default": "",
+          "description": "Override pod serviceAccountName (default application).",
+          "required": [],
+          "title": "serviceAccountName",
+          "type": "null"
+        },
+        "terminationGracePeriodSeconds": {
+          "default": "",
+          "description": "(int) Override pod terminationGracePeriodSeconds (default 30s).",
+          "required": [],
+          "title": "terminationGracePeriodSeconds",
+          "type": "null"
+        },
+        "volumes": {
+          "description": "Configure volume, accepts kubernetes syntax",
+          "items": {
+            "required": []
+          },
+          "required": [],
+          "title": "volumes",
+          "type": "array"
+        }
+      },
+      "required": [
+        "enabled",
+        "labels",
+        "volumes",
+        "replicas",
+        "maxReplicas",
+        "forceReplicas",
+        "terminationGracePeriodSeconds",
+        "minAvailable",
+        "maxSurge",
+        "maxUnavailable",
+        "serviceAccountName",
+        "minReadySeconds"
+      ],
+      "title": "deployment",
+      "type": "object"
+    },
+    "env": {
+      "default": "",
+      "description": "The current env, override in your `values-kub-ent-$env.yaml` files to `dev`, `tst` or `prd`",
+      "required": [],
+      "title": "env",
+      "type": "null"
+    },
+    "global": {
+      "description": "Global values are values that can be accessed from any chart or subchart by exactly the same name.",
+      "required": [],
+      "title": "global",
+      "type": "object"
+    },
+    "grpc": {
+      "default": false,
+      "description": "Enable gRPC which will add an annotation and use grpc probes",
+      "required": [],
+      "title": "grpc",
+      "type": "boolean"
+    },
+    "hpa": {
+      "additionalProperties": false,
+      "properties": {
+        "spec": {
+          "additionalProperties": false,
+          "description": "Custom spec for HPA, inherits `scaleTargetRef` and min/max replicas.\nps: Reason why we have set 100% cpu as default is because the java applications are resource hogs during startup.\n    If you have good startupProbe/readinessProbes in place you can lower the cpu average utilization to ie 50/60%.\n    - Or scale on other (custom) metrics.",
+          "required": [],
+          "title": "spec",
+          "type": "object"
+        }
+      },
+      "required": ["spec"],
+      "title": "hpa",
+      "type": "object"
+    },
+    "ingress": {
+      "additionalProperties": false,
+      "properties": {
+        "annotations": {
+          "additionalProperties": false,
+          "description": "Optionally set annotations for the ingress",
+          "required": [],
+          "title": "annotations",
+          "type": "object"
+        },
+        "enabled": {
+          "default": true,
+          "description": "Enable or disable the ingress",
+          "required": [],
+          "title": "enabled",
+          "type": "boolean"
+        },
+        "host": {
+          "default": "",
+          "description": "Set the host name, do this in your `values-kub-ent-$env.yaml` files",
+          "required": [],
+          "title": "host",
+          "type": "null"
+        },
+        "trafficType": {
+          "default": "",
+          "description": "Set the traffic type (`api`,`public` or `http2` for gRPC)",
+          "required": [],
+          "title": "trafficType",
+          "type": "null"
+        }
+      },
+      "required": ["enabled", "host", "trafficType", "annotations"],
+      "title": "ingress",
+      "type": "object"
+    },
+    "ingresses": {
+      "description": "Specify a list of `ingress` specs",
+      "items": {
+        "required": []
+      },
+      "required": [],
+      "title": "ingresses",
+      "type": "array"
+    },
+    "initContainers": {
+      "description": "Takes a list of initContainers\nSee: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/",
+      "items": {
+        "required": []
+      },
+      "required": [],
+      "title": "initContainers",
+      "type": "array"
+    },
+    "labels": {
+      "additionalProperties": false,
+      "description": "Specify additional labels for every resource",
+      "required": [],
+      "title": "labels",
+      "type": "object"
+    },
+    "pdb": {
+      "additionalProperties": false,
+      "properties": {
+        "minAvailable": {
+          "default": "",
+          "description": "(string) Set minimum available %, this overrides pdb setting minAvailable in deployment/container",
+          "required": [],
+          "title": "minAvailable",
+          "type": "null"
+        }
+      },
+      "required": ["minAvailable"],
+      "title": "pdb",
+      "type": "object"
+    },
+    "postgres": {
+      "additionalProperties": false,
+      "properties": {
+        "connectionConfig": {
+          "default": "",
+          "description": "Override name for connection configmap. This must at least contain `INSTANCES`.",
+          "required": [],
+          "title": "connectionConfig",
+          "type": "null"
+        },
+        "cpu": {
+          "default": 0.05,
+          "description": "Configure cpu request for proxy",
+          "required": [],
+          "title": "cpu",
+          "type": "number"
+        },
+        "cpuLimit": {
+          "default": "",
+          "description": "(float) Configure optional cpu limit for proxy",
+          "required": [],
+          "title": "cpuLimit",
+          "type": "null"
+        },
+        "credentialsSecret": {
+          "default": "",
+          "description": "Override name for credentials secret. This must at least contain `PGUSER` and `PGPASSWORD`.",
+          "required": [],
+          "title": "credentialsSecret",
+          "type": "null"
+        },
+        "enabled": {
+          "default": false,
+          "description": "Enable or disable the proxy",
+          "required": [],
+          "title": "enabled",
+          "type": "boolean"
+        },
+        "memory": {
+          "default": 16,
+          "description": "Configure memory request for proxy without units, `Mi` inferred",
+          "required": [],
+          "title": "memory",
+          "type": "integer"
+        },
+        "memoryLimit": {
+          "default": 16,
+          "description": "Configure memoryLimit for proxy without units, `Mi` inferred",
+          "required": [],
+          "title": "memoryLimit",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "enabled",
+        "cpu",
+        "cpuLimit",
+        "memory",
+        "memoryLimit",
+        "connectionConfig",
+        "credentialsSecret"
+      ],
+      "title": "postgres",
+      "type": "object"
+    },
+    "releaseName": {
+      "default": "",
+      "description": "Override release name, useful for multiple deployments",
+      "required": [],
+      "title": "releaseName",
+      "type": "null"
+    },
+    "secrets": {
+      "additionalProperties": false,
+      "description": "Add externalSecret to sync secrets from secret manager",
+      "required": [],
+      "title": "secrets",
+      "type": "object"
+    },
+    "service": {
+      "additionalProperties": false,
+      "properties": {
+        "annotations": {
+          "additionalProperties": false,
+          "description": "Optionally set annotations for the service",
+          "required": [],
+          "title": "annotations",
+          "type": "object"
+        },
+        "enabled": {
+          "default": true,
+          "description": "Enable or disable the service",
+          "required": [],
+          "title": "enabled",
+          "type": "boolean"
+        },
+        "externalPort": {
+          "default": 80,
+          "description": "Set the external port for your service",
+          "required": [],
+          "title": "externalPort",
+          "type": "integer"
+        },
+        "internalPort": {
+          "default": 8080,
+          "description": "Set the internal port for your service",
+          "required": [],
+          "title": "internalPort",
+          "type": "integer"
+        }
+      },
+      "required": ["enabled", "externalPort", "internalPort", "annotations"],
+      "title": "service",
+      "type": "object"
+    },
+    "shortname": {
+      "default": "",
+      "description": "`id` for GCP 2.0, typically on the form `theapp`. Max 10 characters",
+      "required": [],
+      "title": "shortname",
+      "type": "null"
+    },
+    "team": {
+      "default": "",
+      "description": "Your team name, without a `team-` prefix",
+      "required": [],
+      "title": "team",
+      "type": "null"
+    },
+    "vpa": {
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "default": true,
+          "description": "Enable Vertical Pod Autoscaler to get resource requirement and limit recommendations",
+          "required": [],
+          "title": "enabled",
+          "type": "boolean"
+        }
+      },
+      "required": ["enabled"],
+      "title": "vpa",
+      "type": "object"
+    }
+  },
+  "required": [
+    "app",
+    "shortname",
+    "team",
+    "env",
+    "releaseName",
+    "labels",
+    "ingress",
+    "ingresses",
+    "grpc",
+    "deployment",
+    "cron",
+    "hpa",
+    "pdb",
+    "service",
+    "containers",
+    "container",
+    "initContainers",
+    "postgres",
+    "configmap",
+    "secrets",
+    "vpa"
+  ],
+  "type": "object"
+}

--- a/charts/common/values.schema.json
+++ b/charts/common/values.schema.json
@@ -2,6 +2,10 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "properties": {
+    "global": {
+      "description": "Global values are values that can be accessed from any chart or subchart by exactly the same name.",
+      "type": "object"
+    },
     "app": {
       "description": "Application name, typically on the form `the-application`",
       "type": ["string", "null"]
@@ -251,6 +255,7 @@
           "type": "array"
         }
       },
+      "required": ["image"],
       "type": "object"
     },
     "containers": {
@@ -313,6 +318,7 @@
           "type": "array"
         }
       },
+      "required": ["schedule"],
       "type": "object"
     },
     "deployment": {
@@ -377,11 +383,7 @@
     },
     "env": {
       "description": "The current env, override in your `values-kub-ent-$env.yaml` files to `dev`, `tst` or `prd`",
-      "type": ["object", "null"]
-    },
-    "global": {
-      "description": "Global values are values that can be accessed from any chart or subchart by exactly the same name.",
-      "type": "object"
+      "type": ["string"]
     },
     "grpc": {
       "default": false,
@@ -421,6 +423,7 @@
           "type": ["string", "null"]
         }
       },
+      "required": ["host", "trafficType"],
       "type": "object"
     },
     "ingresses": {
@@ -539,5 +542,6 @@
       "type": "object"
     }
   },
+  "required": ["app", "env", "shortname", "team"],
   "type": "object"
 }

--- a/charts/common/values.schema.json
+++ b/charts/common/values.schema.json
@@ -3,11 +3,8 @@
   "additionalProperties": false,
   "properties": {
     "app": {
-      "default": "",
       "description": "Application name, typically on the form `the-application`",
-      "required": [],
-      "title": "app",
-      "type": "null"
+      "type": "string"
     },
     "configmap": {
       "additionalProperties": false,
@@ -15,126 +12,89 @@
         "data": {
           "additionalProperties": false,
           "description": "Set data for configmap",
-          "required": [],
-          "title": "data",
           "type": "object"
         },
         "enabled": {
           "default": false,
           "description": "Enable or disable the configmap",
-          "required": [],
-          "title": "enabled",
           "type": "boolean"
         }
       },
-      "required": ["enabled", "data"],
-      "title": "configmap",
       "type": "object"
     },
     "container": {
       "additionalProperties": false,
       "properties": {
         "args": {
-          "default": "",
-          "description": "Optionally set the arguments that will be passed to the command, e.g. [\"arg1\",\"arg2\"].",
-          "required": [],
-          "title": "args",
-          "type": "null"
+          "description": "Optionally set the arguments that will be passed to the command",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "examples": ["arg1", "arg2"]
         },
         "command": {
-          "default": "",
           "description": "Optionally set the command that will run in the pod. If not set, the entrypoint for the container-image is used (recommended for most Java-apps).",
-          "required": [],
-          "title": "command",
-          "type": "null"
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "cpu": {
           "default": 0.1,
           "description": "Set CPU without any unit. 100m is 0.1",
-          "required": [],
-          "title": "cpu",
-          "type": "number"
+          "type": ["string", "number"]
         },
         "cpuLimit": {
-          "default": "",
-          "description": "(float) Set CPU limit without any unit. 100m is 0.1",
-          "required": [],
-          "title": "cpuLimit",
-          "type": "null"
+          "description": "Set CPU limit without any unit. 100m is 0.1",
+          "type": ["string", "number"]
         },
         "env": {
-          "description": "- secretRef:\n    name: app-psql-credentials\nSpecify `env` entries for your container",
+          "description": "Specify `env` entries for your container",
           "items": {
-            "required": []
+            "type": "object"
           },
-          "required": [],
-          "title": "env",
           "type": "array"
         },
         "envFrom": {
           "description": "Attach secrets and configmaps to your `env`",
           "items": {
-            "required": []
+            "type": "object"
           },
-          "required": [],
-          "title": "envFrom",
           "type": "array"
         },
         "forceReplicas": {
-          "default": "",
-          "description": "(int) Force replicas disables autoscaling and PDB, if set to 1 it will use Recreate strategy",
-          "required": [],
-          "title": "forceReplicas",
-          "type": "null"
+          "description": "Force replicas disables autoscaling and PDB, if set to 1 it will use Recreate strategy",
+          "type": "integer"
         },
         "labels": {
-          "additionalProperties": false,
           "description": "Add labels to your pods",
-          "required": [],
-          "title": "labels",
           "type": "object"
         },
         "lifecycle": {
-          "additionalProperties": false,
           "description": "Set pod lifecycle handlers",
-          "required": [],
-          "title": "lifecycle",
           "type": "object"
         },
         "maxReplicas": {
-          "default": "",
-          "description": "(int) Set the maxReplicas for your HPA",
-          "required": [],
-          "title": "maxReplicas",
-          "type": "null"
+          "description": "Set the maxReplicas for your HPA",
+          "type": "integer"
         },
         "memory": {
           "default": 16,
           "description": "Set memory without any unit, `Mi` is inferred",
-          "required": [],
-          "title": "memory",
           "type": "integer"
         },
         "memoryLimit": {
-          "default": "",
           "description": "Set memory limit without any unit, `Mi` is inferred",
-          "required": [],
-          "title": "memoryLimit",
-          "type": "null"
+          "type": "integer"
         },
         "minAvailable": {
-          "default": "",
-          "description": "(string) Set the minimal available replicas, used by PDB",
-          "required": [],
-          "title": "minAvailable",
-          "type": "null"
+          "description": "Set the minimal available replicas, used by PDB",
+          "type": "string"
         },
         "name": {
-          "default": "",
           "description": "Name of container",
-          "required": [],
-          "title": "name",
-          "type": "null"
+          "type": "string"
         },
         "probes": {
           "additionalProperties": false,
@@ -142,8 +102,6 @@
             "enabled": {
               "default": true,
               "description": "Enable or disable probes",
-              "required": [],
-              "title": "enabled",
               "type": "boolean"
             },
             "liveness": {
@@ -153,55 +111,33 @@
                 "failureThreshold": {
                   "default": 6,
                   "description": "Set the failure threshold",
-                  "required": [],
-                  "title": "failureThreshold",
                   "type": "integer"
                 },
                 "grpc": {
-                  "default": "",
                   "description": "Specify grpc probes for a port. Needs `port` child stanza",
-                  "required": [],
-                  "title": "grpc",
-                  "type": "null"
+                  "type": "object"
                 },
                 "initialDelaySeconds": {
                   "default": 0,
                   "description": "Set the initial delay for the probe",
-                  "required": [],
-                  "title": "initialDelaySeconds",
                   "type": "integer"
                 },
                 "path": {
                   "default": "/actuator/health/liveness",
                   "description": "Set the path for liveness probe",
-                  "required": [],
-                  "title": "path",
                   "type": "string"
                 },
                 "periodSeconds": {
                   "default": 5,
                   "description": "Set the period of checking",
-                  "required": [],
-                  "title": "periodSeconds",
                   "type": "integer"
                 },
                 "successThreshold": {
                   "default": 1,
                   "description": "Set the success threshold",
-                  "required": [],
-                  "title": "successThreshold",
                   "type": "integer"
                 }
               },
-              "required": [
-                "path",
-                "initialDelaySeconds",
-                "successThreshold",
-                "failureThreshold",
-                "periodSeconds",
-                "grpc"
-              ],
-              "title": "liveness",
               "type": "object"
             },
             "readiness": {
@@ -210,63 +146,38 @@
                 "failureThreshold": {
                   "default": 6,
                   "description": "Set the failure threshold",
-                  "required": [],
-                  "title": "failureThreshold",
                   "type": "integer"
                 },
                 "grpc": {
-                  "default": "",
                   "description": "Specify grpc probes for a port. Needs `port` child stanza",
-                  "required": [],
-                  "title": "grpc",
-                  "type": "null"
+                  "type": "object"
                 },
                 "initialDelaySeconds": {
                   "default": 0,
                   "description": "Set the initial delay for the probe",
-                  "required": [],
-                  "title": "initialDelaySeconds",
                   "type": "integer"
                 },
                 "path": {
                   "default": "/actuator/health/readiness",
                   "description": "Set the path for liveness probe",
-                  "required": [],
-                  "title": "path",
                   "type": "string"
                 },
                 "periodSeconds": {
                   "default": 5,
                   "description": "Set the period of checking",
-                  "required": [],
-                  "title": "periodSeconds",
                   "type": "integer"
                 },
                 "successThreshold": {
                   "default": 1,
                   "description": "Set the success threshold",
-                  "required": [],
-                  "title": "successThreshold",
                   "type": "integer"
                 }
               },
-              "required": [
-                "path",
-                "initialDelaySeconds",
-                "successThreshold",
-                "failureThreshold",
-                "periodSeconds",
-                "grpc"
-              ],
-              "title": "readiness",
               "type": "object"
             },
             "spec": {
-              "default": "",
               "description": "Override with k8s spec for custom probes",
-              "required": [],
-              "title": "spec",
-              "type": "null"
+              "type": "object"
             },
             "startup": {
               "additionalProperties": false,
@@ -274,32 +185,21 @@
                 "failureThreshold": {
                   "default": 300,
                   "description": "Set the failure threshold",
-                  "required": [],
-                  "title": "failureThreshold",
                   "type": "integer"
                 },
                 "grpc": {
-                  "default": "",
                   "description": "Specify grpc probes for a port. Needs `port` child stanza",
-                  "required": [],
-                  "title": "grpc",
-                  "type": "null"
+                  "type": "object"
                 },
                 "periodSeconds": {
                   "default": 1,
                   "description": "Set the period of checking",
-                  "required": [],
-                  "title": "periodSeconds",
                   "type": "integer"
                 }
               },
-              "required": ["failureThreshold", "periodSeconds", "grpc"],
-              "title": "startup",
               "type": "object"
             }
           },
-          "required": ["enabled", "spec", "liveness", "readiness", "startup"],
-          "title": "probes",
           "type": "object"
         },
         "prometheus": {
@@ -309,201 +209,110 @@
             "enabled": {
               "default": false,
               "description": "Enable or disable Prometheus",
-              "required": [],
-              "title": "enabled",
               "type": "boolean"
             },
             "path": {
               "default": "/actuator/prometheus",
               "description": "Set the path for scraping metrics",
-              "required": [],
-              "title": "path",
               "type": "string"
             },
             "port": {
-              "default": "",
-              "description": "(int) Set the port for prometheus scraping",
-              "required": [],
-              "title": "port",
-              "type": "null"
+              "description": "Set the port for prometheus scraping",
+              "type": "integer"
             }
           },
-          "required": ["enabled", "path", "port"],
-          "title": "prometheus",
           "type": "object"
         },
         "replicas": {
-          "default": "",
-          "description": "(int) Set the target replica count, if equal to 1 the PDB minAvailable will be set to 100%",
-          "required": [],
-          "title": "replicas",
-          "type": "null"
+          "description": "Set the target replica count, if equal to 1 the PDB minAvailable will be set to 100%",
+          "type": "integer"
         },
         "terminationGracePeriodSeconds": {
-          "default": "",
-          "description": "(int) Override pod terminationGracePeriodSeconds (default 30s).",
-          "required": [],
-          "title": "terminationGracePeriodSeconds",
-          "type": "null"
+          "description": "Override pod terminationGracePeriodSeconds (default 30s).",
+          "type": "integer"
         },
         "uid": {
           "default": 1000,
           "description": "Set the uid that your user runs with",
-          "required": [],
-          "title": "uid",
           "type": "integer"
         },
         "volumeMounts": {
           "description": "Configure volume mounts, accepts kubernetes syntax",
           "items": {
-            "required": []
+            "type": "object"
           },
-          "required": [],
-          "title": "volumeMounts",
           "type": "array"
         },
         "volumes": {
           "description": "Configure volume, accepts kubernetes syntax",
           "items": {
-            "required": []
+            "type": "object"
           },
-          "required": [],
-          "title": "volumes",
           "type": "array"
         }
       },
-      "required": [
-        "name",
-        "labels",
-        "command",
-        "args",
-        "cpu",
-        "cpuLimit",
-        "memory",
-        "memoryLimit",
-        "uid",
-        "replicas",
-        "forceReplicas",
-        "minAvailable",
-        "maxReplicas",
-        "envFrom",
-        "env",
-        "prometheus",
-        "probes",
-        "volumeMounts",
-        "volumes",
-        "terminationGracePeriodSeconds",
-        "lifecycle"
-      ],
-      "title": "container",
       "type": "object"
     },
     "containers": {
       "description": "Takes a list of `container` entries, you must add a `name` field for each entry",
       "items": {
-        "required": []
+        "$ref": "#/properties/container"
       },
-      "required": [],
-      "title": "containers",
       "type": "array"
     },
     "cron": {
       "additionalProperties": false,
       "properties": {
         "concurrencyPolicy": {
-          "default": "",
           "description": "Concurrency policy",
-          "required": [],
-          "title": "concurrencyPolicy",
-          "type": "null"
+          "type": "string"
         },
         "enabled": {
           "default": false,
           "description": "Enable or disable the cron job",
-          "required": [],
-          "title": "enabled",
           "type": "boolean"
         },
         "failedJobsHistoryLimit": {
-          "default": "",
-          "description": "(int) Failed jobs history limit",
-          "required": [],
-          "title": "failedJobsHistoryLimit",
-          "type": "null"
+          "description": "Failed jobs history limit",
+          "type": "integer"
         },
         "labels": {
           "additionalProperties": false,
           "description": "Add labels to your pods",
-          "required": [],
-          "title": "labels",
           "type": "object"
         },
         "restartPolicy": {
-          "default": "",
           "description": "Override pod restartPolicy (default OnFailure).",
-          "required": [],
-          "title": "restartPolicy",
-          "type": "null"
+          "type": "string"
         },
         "schedule": {
-          "default": "",
           "description": "Required crontab schedule `* * * * * *`",
-          "required": [],
-          "title": "schedule",
-          "type": "null"
+          "type": "string"
         },
         "serviceAccountName": {
-          "default": "",
           "description": "Override pod serviceAccountName (default application).",
-          "required": [],
-          "title": "serviceAccountName",
-          "type": "null"
+          "type": "string"
         },
         "successfulJobsHistoryLimit": {
-          "default": "",
-          "description": "(int) Successful jobs history limit",
-          "required": [],
-          "title": "successfulJobsHistoryLimit",
-          "type": "null"
+          "description": "Successful jobs history limit",
+          "type": "integer"
         },
         "suspend": {
-          "default": "",
           "description": "Suspend flag",
-          "required": [],
-          "title": "suspend",
-          "type": "null"
+          "type": "boolean"
         },
         "terminationGracePeriodSeconds": {
-          "default": "",
-          "description": "(int) Override pod terminationGracePeriodSeconds (default 30s).",
-          "required": [],
-          "title": "terminationGracePeriodSeconds",
-          "type": "null"
+          "description": "Override pod terminationGracePeriodSeconds (default 30s).",
+          "type": "integer"
         },
         "volumes": {
           "description": "Configure volume, accepts kubernetes syntax",
           "items": {
-            "required": []
+            "type": "object"
           },
-          "required": [],
-          "title": "volumes",
           "type": "array"
         }
       },
-      "required": [
-        "enabled",
-        "concurrencyPolicy",
-        "failedJobsHistoryLimit",
-        "schedule",
-        "successfulJobsHistoryLimit",
-        "suspend",
-        "labels",
-        "volumes",
-        "terminationGracePeriodSeconds",
-        "restartPolicy",
-        "serviceAccountName"
-      ],
-      "title": "cron",
       "type": "object"
     },
     "deployment": {
@@ -512,125 +321,71 @@
         "enabled": {
           "default": true,
           "description": "Enable or disable the deployment",
-          "required": [],
-          "title": "enabled",
           "type": "boolean"
         },
         "forceReplicas": {
-          "default": "",
-          "description": "(int) Force replicas disables autoscaling and PDB, if set to 1 it will use Recreate strategy",
-          "required": [],
-          "title": "forceReplicas",
-          "type": "null"
+          "description": "Force replicas disables autoscaling and PDB, if set to 1 it will use Recreate strategy",
+          "type": "integer"
         },
         "labels": {
           "additionalProperties": false,
           "description": "Add labels to your pods",
-          "required": [],
-          "title": "labels",
           "type": "object"
         },
         "maxReplicas": {
-          "default": "",
           "description": "Set the max replica count",
-          "required": [],
-          "title": "maxReplicas",
-          "type": "null"
+          "type": "integer"
         },
         "maxSurge": {
-          "default": "",
           "description": "Limit max surge for rolling updates (default 25%). Not in use when using forceReplicas.",
-          "required": [],
-          "title": "maxSurge",
-          "type": "null"
+          "type": "string"
         },
         "maxUnavailable": {
-          "default": "",
           "description": "Limit max unavailable for rolling updates (default 25%). Not in use when using forceReplicas.",
-          "required": [],
-          "title": "maxUnavailable",
-          "type": "null"
+          "type": "string"
         },
         "minAvailable": {
-          "default": "",
-          "description": "(string) Set minimum available %",
-          "required": [],
-          "title": "minAvailable",
-          "type": "null"
+          "description": "Set minimum available %",
+          "type": "string"
         },
         "minReadySeconds": {
           "default": 0,
           "description": "See https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#progress-deadline-seconds",
-          "required": [],
-          "title": "minReadySeconds",
           "type": "integer"
         },
         "replicas": {
-          "default": "",
-          "description": "Prometheus\nprometheus: same as container.prometheus stanza\nSet the target replica count",
-          "required": [],
-          "title": "replicas",
-          "type": "null"
+          "description": "Set the target replica count",
+          "type": "integer"
         },
         "serviceAccountName": {
-          "default": "",
           "description": "Override pod serviceAccountName (default application).",
-          "required": [],
-          "title": "serviceAccountName",
-          "type": "null"
+          "type": "string"
         },
         "terminationGracePeriodSeconds": {
-          "default": "",
           "description": "(int) Override pod terminationGracePeriodSeconds (default 30s).",
-          "required": [],
-          "title": "terminationGracePeriodSeconds",
-          "type": "null"
+          "type": "integer"
         },
         "volumes": {
           "description": "Configure volume, accepts kubernetes syntax",
           "items": {
-            "required": []
+            "type": "object"
           },
-          "required": [],
-          "title": "volumes",
           "type": "array"
         }
       },
-      "required": [
-        "enabled",
-        "labels",
-        "volumes",
-        "replicas",
-        "maxReplicas",
-        "forceReplicas",
-        "terminationGracePeriodSeconds",
-        "minAvailable",
-        "maxSurge",
-        "maxUnavailable",
-        "serviceAccountName",
-        "minReadySeconds"
-      ],
-      "title": "deployment",
       "type": "object"
     },
     "env": {
-      "default": "",
       "description": "The current env, override in your `values-kub-ent-$env.yaml` files to `dev`, `tst` or `prd`",
-      "required": [],
-      "title": "env",
-      "type": "null"
+      "type": "object"
     },
     "global": {
       "description": "Global values are values that can be accessed from any chart or subchart by exactly the same name.",
-      "required": [],
-      "title": "global",
       "type": "object"
     },
     "grpc": {
       "default": false,
       "description": "Enable gRPC which will add an annotation and use grpc probes",
-      "required": [],
-      "title": "grpc",
       "type": "boolean"
     },
     "hpa": {
@@ -639,13 +394,9 @@
         "spec": {
           "additionalProperties": false,
           "description": "Custom spec for HPA, inherits `scaleTargetRef` and min/max replicas.\nps: Reason why we have set 100% cpu as default is because the java applications are resource hogs during startup.\n    If you have good startupProbe/readinessProbes in place you can lower the cpu average utilization to ie 50/60%.\n    - Or scale on other (custom) metrics.",
-          "required": [],
-          "title": "spec",
           "type": "object"
         }
       },
-      "required": ["spec"],
-      "title": "hpa",
       "type": "object"
     },
     "ingress": {
@@ -654,204 +405,127 @@
         "annotations": {
           "additionalProperties": false,
           "description": "Optionally set annotations for the ingress",
-          "required": [],
-          "title": "annotations",
           "type": "object"
         },
         "enabled": {
           "default": true,
           "description": "Enable or disable the ingress",
-          "required": [],
-          "title": "enabled",
           "type": "boolean"
         },
         "host": {
-          "default": "",
           "description": "Set the host name, do this in your `values-kub-ent-$env.yaml` files",
-          "required": [],
-          "title": "host",
-          "type": "null"
+          "type": "string"
         },
         "trafficType": {
-          "default": "",
           "description": "Set the traffic type (`api`,`public` or `http2` for gRPC)",
-          "required": [],
-          "title": "trafficType",
-          "type": "null"
+          "type": "string"
         }
       },
-      "required": ["enabled", "host", "trafficType", "annotations"],
-      "title": "ingress",
       "type": "object"
     },
     "ingresses": {
       "description": "Specify a list of `ingress` specs",
       "items": {
-        "required": []
+        "$ref": "#/properties/ingress"
       },
-      "required": [],
-      "title": "ingresses",
       "type": "array"
     },
     "initContainers": {
       "description": "Takes a list of initContainers\nSee: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/",
       "items": {
-        "required": []
+        "type": "object"
       },
-      "required": [],
-      "title": "initContainers",
       "type": "array"
     },
     "labels": {
-      "additionalProperties": false,
       "description": "Specify additional labels for every resource",
-      "required": [],
-      "title": "labels",
       "type": "object"
     },
     "pdb": {
-      "additionalProperties": false,
       "properties": {
         "minAvailable": {
-          "default": "",
-          "description": "(string) Set minimum available %, this overrides pdb setting minAvailable in deployment/container",
-          "required": [],
-          "title": "minAvailable",
-          "type": "null"
+          "description": "Set minimum available %, this overrides pdb setting minAvailable in deployment/container",
+          "type": "string"
         }
       },
-      "required": ["minAvailable"],
-      "title": "pdb",
       "type": "object"
     },
     "postgres": {
-      "additionalProperties": false,
       "properties": {
         "connectionConfig": {
-          "default": "",
           "description": "Override name for connection configmap. This must at least contain `INSTANCES`.",
-          "required": [],
-          "title": "connectionConfig",
-          "type": "null"
+          "type": "string"
         },
         "cpu": {
           "default": 0.05,
           "description": "Configure cpu request for proxy",
-          "required": [],
-          "title": "cpu",
           "type": "number"
         },
         "cpuLimit": {
-          "default": "",
-          "description": "(float) Configure optional cpu limit for proxy",
-          "required": [],
-          "title": "cpuLimit",
-          "type": "null"
+          "description": "Configure optional cpu limit for proxy",
+          "type": "number"
         },
         "credentialsSecret": {
-          "default": "",
           "description": "Override name for credentials secret. This must at least contain `PGUSER` and `PGPASSWORD`.",
-          "required": [],
-          "title": "credentialsSecret",
-          "type": "null"
+          "type": "string"
         },
         "enabled": {
           "default": false,
           "description": "Enable or disable the proxy",
-          "required": [],
-          "title": "enabled",
           "type": "boolean"
         },
         "memory": {
           "default": 16,
           "description": "Configure memory request for proxy without units, `Mi` inferred",
-          "required": [],
-          "title": "memory",
           "type": "integer"
         },
         "memoryLimit": {
           "default": 16,
           "description": "Configure memoryLimit for proxy without units, `Mi` inferred",
-          "required": [],
-          "title": "memoryLimit",
           "type": "integer"
         }
       },
-      "required": [
-        "enabled",
-        "cpu",
-        "cpuLimit",
-        "memory",
-        "memoryLimit",
-        "connectionConfig",
-        "credentialsSecret"
-      ],
-      "title": "postgres",
       "type": "object"
     },
     "releaseName": {
-      "default": "",
       "description": "Override release name, useful for multiple deployments",
-      "required": [],
-      "title": "releaseName",
-      "type": "null"
+      "type": "string"
     },
     "secrets": {
-      "additionalProperties": false,
       "description": "Add externalSecret to sync secrets from secret manager",
-      "required": [],
-      "title": "secrets",
       "type": "object"
     },
     "service": {
-      "additionalProperties": false,
       "properties": {
         "annotations": {
-          "additionalProperties": false,
           "description": "Optionally set annotations for the service",
-          "required": [],
-          "title": "annotations",
           "type": "object"
         },
         "enabled": {
           "default": true,
           "description": "Enable or disable the service",
-          "required": [],
-          "title": "enabled",
           "type": "boolean"
         },
         "externalPort": {
           "default": 80,
           "description": "Set the external port for your service",
-          "required": [],
-          "title": "externalPort",
           "type": "integer"
         },
         "internalPort": {
           "default": 8080,
           "description": "Set the internal port for your service",
-          "required": [],
-          "title": "internalPort",
           "type": "integer"
         }
       },
-      "required": ["enabled", "externalPort", "internalPort", "annotations"],
-      "title": "service",
       "type": "object"
     },
     "shortname": {
-      "default": "",
       "description": "`id` for GCP 2.0, typically on the form `theapp`. Max 10 characters",
-      "required": [],
-      "title": "shortname",
-      "type": "null"
+      "type": "string"
     },
     "team": {
-      "default": "",
       "description": "Your team name, without a `team-` prefix",
-      "required": [],
-      "title": "team",
-      "type": "null"
+      "type": "string"
     },
     "vpa": {
       "additionalProperties": false,
@@ -859,38 +533,11 @@
         "enabled": {
           "default": true,
           "description": "Enable Vertical Pod Autoscaler to get resource requirement and limit recommendations",
-          "required": [],
-          "title": "enabled",
           "type": "boolean"
         }
       },
-      "required": ["enabled"],
-      "title": "vpa",
       "type": "object"
     }
   },
-  "required": [
-    "app",
-    "shortname",
-    "team",
-    "env",
-    "releaseName",
-    "labels",
-    "ingress",
-    "ingresses",
-    "grpc",
-    "deployment",
-    "cron",
-    "hpa",
-    "pdb",
-    "service",
-    "containers",
-    "container",
-    "initContainers",
-    "postgres",
-    "configmap",
-    "secrets",
-    "vpa"
-  ],
   "type": "object"
 }


### PR DESCRIPTION
This PR introduces the [Helm JSON schema file](https://helm.sh/docs/topics/charts/#schema-files) which allows automatic validation of the provided Helm values when executing `helm install`, `helm upgrade`, `helm lint`, `helm template`.

The main benefit of this is to catch situations where the user of the chart provides some nested value which actually does not exists and the user assumes that it works since the `helm apply` does not throw any errors.

I tried to be as non-disruptive as possible with the schema, so it should work with existing installations. But we need to bump the minor version of the chart because the `helm apply` will fail if there are any extra values provided.
