### PR TITLE
feat: ETU-70853 Make Cloud SQL Proxy term_timeout configurable

### DIFF
--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -80,5 +80,5 @@ description: >
 
   </details>
 type: application
-version: 1.21.1
+version: 1.21.2
 appVersion: 0.0.1

--- a/charts/common/templates/_helpers.tpl
+++ b/charts/common/templates/_helpers.tpl
@@ -176,7 +176,7 @@ livenessProbe:
     - "-verbose=false"
     - "-log_debug_stdout=true"
     - "-structured_logs=true"
-    - "-term_timeout=30s"
+    - "-term_timeout={{ .postgres.termTimeout | default "30s" }}"
   envFrom:
   - configMapRef:
   {{- if .postgres.connectionConfig }}

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -275,6 +275,11 @@ postgres:
   connectionConfig:
   # -- Override name for credentials secret. This must at least contain `PGUSER` and `PGPASSWORD`.
   credentialsSecret:
+  # -- Override the term_timeout for the Cloud SQL Proxy. Controls how long the proxy waits for
+  # existing connections to close after receiving SIGTERM before force-closing them.
+  # Increase this if your app runs long-lived jobs that need the database during pod termination.
+  # @default -- 30s
+  termTimeout:
 
 configmap:
   # -- Enable or disable the configmap


### PR DESCRIPTION
## What and why

The Cloud SQL Proxy sidecar has `-term_timeout` hardcoded to `30s`. This controls how long the proxy waits for existing connections to drain after receiving `SIGTERM` before force-closing them.

For services with long-lived jobs (e.g. batch processing that writes to the database), the proxy tears down database connections after 30s even when the pod's `terminationGracePeriodSeconds` is set much higher. This causes in-flight jobs to lose their DB connection mid-run during rolling deployments.

## Changes

- `_helpers.tpl`: replace hardcoded `-term_timeout=30s` with `{{ .postgres.termTimeout | default "30s" }}` — backwards compatible, default unchanged
- `values.yaml`: add `postgres.termTimeout` with doc comment
- `Chart.yaml`: bump to `1.21.2`

## Testing

Consumers can now set:
```yaml
postgres:
  termTimeout: 3600s
```
to align the proxy's connection drain timeout with their pod's `terminationGracePeriodSeconds`.