### PR TITLE
feat(common): make imagePullPolicy configurable

### DIFF
--- a/charts/common/templates/cron.yaml
+++ b/charts/common/templates/cron.yaml
@@ -10,6 +10,7 @@
 {{- $postgres := .Values.postgres -}}
 {{- $secrets := .Values.secrets -}}
 {{- $cronjob := .Values.cron -}}
+{{- $globalPullPolicy := .Values.imagePullPolicy | default "Always" -}}
 {{- if $cronjob.enabled -}}
 {{- /* YAML Spec */}}
 
@@ -57,7 +58,7 @@ spec:
             {{- printf "\n            " -}}
             - name: {{ .name | default $app }}
               image: {{ $image }}
-              imagePullPolicy: Always
+              imagePullPolicy: {{ .pullPolicy | default $globalPullPolicy }}
               {{- if .command }}
               command: {{ .command }}
               {{- end }}

--- a/charts/common/templates/deployment.yaml
+++ b/charts/common/templates/deployment.yaml
@@ -23,6 +23,7 @@
 {{- $maxSurge := .Values.deployment.maxSurge | default "25%" }}
 {{- $maxUnavailable := .Values.deployment.maxUnavailable | default "25%" }}
 {{- $hpa := .Values.hpa | default dict }}
+{{- $globalPullPolicy := .Values.imagePullPolicy | default "Always" }}
 {{- if $enabled }}
 {{- /* YAML Spec */}}
 apiVersion: apps/v1
@@ -82,7 +83,7 @@ spec:
         {{- printf "\n        " -}}
         - name: {{ .name | default $app }}
           image: {{ $image }}
-          imagePullPolicy: Always
+          imagePullPolicy: {{ .pullPolicy | default $globalPullPolicy }}
           {{- if .command }}
           command: {{ .command }}
           {{- end }}

--- a/charts/common/tests/cron_test.yaml
+++ b/charts/common/tests/cron_test.yaml
@@ -240,3 +240,27 @@ tests:
       - equal:
           path: spec.jobTemplate.spec.activeDeadlineSeconds
           value: 1200
+  - it: imagePullPolicy defaults to Always
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[0].imagePullPolicy
+          value: Always
+  - it: imagePullPolicy can be overridden globally
+    set:
+      imagePullPolicy: Never
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[0].imagePullPolicy
+          value: Never
+  - it: per-container pullPolicy takes precedence over global imagePullPolicy
+    set:
+      imagePullPolicy: Never
+      containers:
+        - image: img
+          pullPolicy: IfNotPresent
+          probes:
+            enabled: false
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[0].imagePullPolicy
+          value: IfNotPresent

--- a/charts/common/tests/deployment_test.yaml
+++ b/charts/common/tests/deployment_test.yaml
@@ -592,6 +592,41 @@ tests:
       - equal:
           path: spec.minReadySeconds
           value: 10
+  - it: imagePullPolicy defaults to Always
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: Always
+  - it: imagePullPolicy can be overridden globally
+    set:
+      imagePullPolicy: Never
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: Never
+  - it: imagePullPolicy can be overridden per container
+    set:
+      containers:
+        - image: img
+          pullPolicy: IfNotPresent
+          probes:
+            enabled: false
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: IfNotPresent
+  - it: per-container pullPolicy takes precedence over global imagePullPolicy
+    set:
+      imagePullPolicy: Never
+      containers:
+        - image: img
+          pullPolicy: Always
+          probes:
+            enabled: false
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: Always
   - it: can set initContainers
     set:
       initContainers:

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -13,6 +13,10 @@ releaseName:
 # @default -- `{ app shortname team common:version environment }`
 labels: {}
 
+# -- Override image pull policy for all containers. Useful for local cluster testing (kind/k3s) where images are loaded directly. Valid values: Always, IfNotPresent, Never
+# @default -- Always
+imagePullPolicy:
+
 ingress:
   # -- Enable or disable the ingress
   enabled: true
@@ -139,6 +143,8 @@ container:
   # -- Name of container
   # @default -- .app
   name:
+  # -- Override image pull policy for this container. Overrides the global `imagePullPolicy`. Valid values: Always, IfNotPresent, Never
+  pullPolicy:
   # -- Add labels to your pods
   labels: {}
   # -- Optionally set the command that will run in the pod. If not set, the entrypoint for the container-image is used (recommended for most Java-apps).


### PR DESCRIPTION
## Background

When developing and testing applications locally using a Kubernetes cluster running in Docker (e.g. [kind](https://kind.sigs.k8s.io/)), images are typically loaded directly into the cluster using `kind load docker-image` rather than being pushed to a remote registry. In this workflow, Kubernetes should not attempt to pull the image from a registry — it should use the locally loaded image as-is.

Currently, `imagePullPolicy` is hardcoded to `Always` in the common chart, making this local development workflow impossible without workarounds.

## Changes

- Adds a global `imagePullPolicy` value that applies to all containers. Defaults to `Always`, so existing deployments are unaffected.
- Adds a per-container `pullPolicy` field that overrides the global value for that specific container.

## Usage

A typical local development setup with a `values-local.yaml`:

```yaml
imagePullPolicy: Never
```

Combined with:

```bash
docker build -t my-app:local .
kind load docker-image my-app:local
helm upgrade --install myapp . -f values.yaml -f values-local.yaml
```

For multi-container pods where only one container uses a local image:

```yaml
common:
  containers:
    - name: myapp
      image: my-app:local
      pullPolicy: Never
    - name: sidecar
      image: eu.gcr.io/entur/sidecar:1.0
      # uses global default (Always)
```

## Compatibility

Fully backwards compatible — the default remains `Always`.