### PR TITLE
docs: fix v2 release candidate version reference

### DIFF
--- a/.claude/skills/upgrade-common-chart/SKILL.md
+++ b/.claude/skills/upgrade-common-chart/SKILL.md
@@ -24,12 +24,12 @@ Read each file before making changes. The common chart is typically referenced a
 
 ## Step 2: Update Chart.yaml
 
-Bump the common chart dependency version to `2.0.0-rc.1`:
+Bump the common chart dependency version to `2.0.0-rc-1`:
 
 ```yaml
 dependencies:
   - name: common
-    version: 2.0.0-rc.1
+    version: 2.0.0-rc-1
     repository: "https://entur.github.io/helm-charts"
 ```
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -15,7 +15,7 @@ v2 is currently available as a release candidate. To test it before the final re
 ```yaml
 dependencies:
   - name: common
-    version: 2.0.0-rc.1
+    version: 2.0.0-rc-1
     repository: https://entur.github.io/helm-charts
 ```
 


### PR DESCRIPTION
## Summary
- Fix the version reference for the v2 release candidate in `UPGRADE.md` and the `upgrade-common-chart` skill: `2.0.0-rc.1` → `2.0.0-rc-1` (hyphen, not dot), matching the actual chart version published in `charts/common/Chart.yaml` and the `common-v2.0.0-rc-1` release tag.

## Test plan
- [ ] Verify the version in the upgrade guide matches `charts/common/Chart.yaml`
- [ ] Confirm `helm dependency update` resolves against `https://entur.github.io/helm-charts` using the documented version

Generated with [Claude Code](https://claude.com/claude-code) using Claude Opus 4.7