### PR TITLE
feat: Add support for service.selector override

### DIFF
--- a/charts/common/templates/service.yaml
+++ b/charts/common/templates/service.yaml
@@ -28,6 +28,10 @@ spec:
     targetPort: {{ .Values.service.internalPort }}
   {{- end }}
   selector:
+  {{- if .Values.service.selector }}
+  {{- toYaml .Values.service.selector | nindent 4 }}
+  {{- else }}
     app: {{ $releaseName }}
+  {{- end }}
   type: ClusterIP
 {{- end }}

--- a/charts/common/tests/service_test.yaml
+++ b/charts/common/tests/service_test.yaml
@@ -70,3 +70,14 @@ tests:
       - equal:
           path: metadata.name
           value: override
+  - it: can override selector
+    set:
+      service:
+        selector:
+          traffic-pool: override
+    asserts:
+      - equal:
+          path: spec.selector["traffic-pool"]
+          value: override
+      - isNull:
+          path: spec.selector.app

--- a/charts/common/values.schema.json
+++ b/charts/common/values.schema.json
@@ -250,6 +250,10 @@
           "description": "Custom ports spec, overrides default port config",
           "items": { "type": "object" },
           "type": "array"
+        },
+        "selector": {
+          "description": "Optionally override the Service selector. Defaults to app: <release-name>",
+          "type": "object"
         }
       },
       "type": "object"

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -177,6 +177,8 @@ service:
   internalPort: 8080
   # -- Optionally set annotations for the service
   annotations: {}
+  # -- Optionally override the Service selector. Defaults to app: <release-name>
+  selector: {}
 
 # -- Takes a list of `container` entries, you must add a `name` field for each entry
 containers: []


### PR DESCRIPTION
Utfordring:

Common chart hardkoder Service-selektoren til app: `<release-name>`. Dette fungerer fint for enkle deployments, men blir en utfordring når flere Helm-releaser skal dele samme nettverkstrafikk.

Eksempel: canary-deployments. Når vi deployer en **pricingservice-canary** ved siden av **pricingservice**, får canary-podene labelen app: pricingservice-canary som ikke blir valgt i rutingen. Det finnes ingen måte å rute produksjonstrafikk til canary-podene på uten å bruke manuell kubectl patch på Servicen, noe som introduserer RBAC-bekymringer rundt github service account, skjørhet rundt Helm-rekonsiliering og operasjonelt overhead ved hver canary-deploy og teardown.

Forslag til løsning:

Eksponerer service.selector som en valgfri overstyring. Når den er satt, erstatter den standard app: <release-name>-selektoren fullstendig. Når den ikke er satt, er oppførselen uendret.

Dette lar et canary-chart deklarere sin egen selektor som matcher en felles label på tvers av både hoved- og canary-podene                                                                                                                  

Endringer:

- templates/service.yaml — selektoren faller tilbake til app: <release-name> når service.selector er tom
- values.yaml — standard service.selector: {} 
- values.schema.json — schema-innslag lagt til (påkrevd på grunn av additionalProperties: false)
- tests/service_test.yaml — test verifiserer at egendefinert selektor brukes og at standard app-label er fraværende 

Se gjerne over og si hva dere tenker.